### PR TITLE
Initialized mock for unit tests

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -9,6 +9,9 @@ type MockIdentifiable struct {
 	ExpectedValidationError error
 }
 
+// MockIdentifiablesList mocks IdentifiablesList
+type MockIdentifiablesList []MockIdentifiable
+
 // Identity returns the Identity of the of the receiver.
 func (p *MockIdentifiable) Identity() Identity {
 	return MakeIdentity(p.DefinedIdentity, "MockCategory")
@@ -34,6 +37,7 @@ func (p *MockIdentifiable) Validate() error {
 	return p.ExpectedValidationError
 }
 
+// MockElementalRequest creates an elemental request from an http request
 func MockElementalRequest(req *http.Request) *Request {
 	r := NewRequest()
 	r.Headers.Set("Origin", req.Header.Get("Origin"))


### PR DESCRIPTION
In a context where we always need to add unit tests, it is very useful that our library - that are already well designed - are providing some mock objects.

Elemental now provides a MockIdentifiable which is a concrete struct that can be instantiated and allows the developer to override its property with:
* `Defined` property values
* `Expected` return values