### PR TITLE
new: move manipulate.FIlter in elemental

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,352 @@
+// Copyright 2019 Aporeto Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elemental
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFilterComparator_NewFilterComparators(t *testing.T) {
+
+	Convey("Given I create a empty FilterComparators with 2 comparators", t, func() {
+
+		fc := FilterComparators{EqualComparator, InComparator}
+
+		Convey("Then it should should not be empty", func() {
+			So(len(fc), ShouldEqual, 2)
+		})
+
+		Convey("Then it should be correctly populated", func() {
+			So(fc, ShouldResemble, FilterComparators{EqualComparator, InComparator})
+		})
+
+		Convey("When I use Then to add 2 other comparators", func() {
+
+			fc = fc.add(ContainComparator, GreaterComparator)
+
+			Convey("Then it should be correctly populated", func() {
+				So(fc, ShouldResemble, FilterComparators{
+					EqualComparator,
+					InComparator,
+					ContainComparator,
+					GreaterComparator,
+				})
+			})
+		})
+	})
+}
+
+func TestFilter_NewFilter(t *testing.T) {
+
+	Convey("Given I create a new filter", t, func() {
+
+		f := NewFilter()
+
+		Convey("Then the filter should implement the correct interfaces", func() {
+			So(f, ShouldImplement, (*FilterKeyComposer)(nil))
+			So(f, ShouldImplement, (*FilterValueComposer)(nil))
+		})
+
+		Convey("Then all values should be initialized", func() {
+			So(f.keys, ShouldResemble, FilterKeys{})
+			So(f.values, ShouldResemble, FilterValues{})
+			So(f.operators, ShouldResemble, FilterOperators{})
+			So(f.comparators, ShouldResemble, FilterComparators{})
+			So(f.ands, ShouldResemble, SubFilters{})
+			So(f.ors, ShouldResemble, SubFilters{})
+		})
+	})
+}
+
+func TestFilter_NewComposer(t *testing.T) {
+
+	Convey("Given I create a new FilterComposer", t, func() {
+
+		f := NewFilterComposer().Done()
+
+		Convey("When I add the initial Equals statement", func() {
+
+			f.WithKey("hello").Equals(1)
+
+			Convey("Then the filter should be correctly populated", func() {
+				So(f.Keys(), ShouldResemble, FilterKeys{"hello"})
+				So(f.Values(), ShouldResemble, FilterValues{FilterValue{1}})
+				So(f.Operators(), ShouldResemble, FilterOperators{AndOperator})
+				So(f.Comparators(), ShouldResemble, FilterComparators{EqualComparator})
+			})
+
+			Convey("When I add a new GreaterThan statement", func() {
+
+				f.WithKey("gt").GreaterThan(12)
+
+				Convey("Then the filter should be correctly populated", func() {
+
+					So(f.Keys(), ShouldResemble, FilterKeys{
+						"hello",
+						"gt",
+					})
+					So(f.Values(), ShouldResemble, FilterValues{
+						FilterValue{1},
+						FilterValue{12},
+					})
+					So(f.Operators(), ShouldResemble, FilterOperators{
+						AndOperator,
+						AndOperator,
+					})
+					So(f.Comparators(), ShouldResemble, FilterComparators{
+						EqualComparator,
+						GreaterComparator,
+					})
+
+					Convey("When I add a new LesserThan statement", func() {
+
+						f.WithKey("lt").LesserThan(13)
+						f.WithKey("gte").GreaterOrEqualThan(22)
+						f.WithKey("lte").LesserOrEqualThan(23)
+
+						Convey("Then the filter should be correctly populated", func() {
+							So(f.Keys(), ShouldResemble, FilterKeys{
+								"hello",
+								"gt",
+								"lt",
+								"gte",
+								"lte",
+							})
+							So(f.Values(), ShouldResemble, FilterValues{
+								FilterValue{1},
+								FilterValue{12},
+								FilterValue{13},
+								FilterValue{22},
+								FilterValue{23},
+							})
+							So(f.Operators(), ShouldResemble, FilterOperators{
+								AndOperator,
+								AndOperator,
+								AndOperator,
+								AndOperator,
+								AndOperator,
+							})
+							So(f.Comparators(), ShouldResemble, FilterComparators{
+								EqualComparator,
+								GreaterComparator,
+								LesserComparator,
+								GreaterOrEqualComparator,
+								LesserOrEqualComparator,
+							})
+						})
+
+						Convey("Then the string representation should be correct", func() {
+							So(f.String(), ShouldEqual, `hello == 1 and gt > 12 and lt < 13 and gte >= 22 and lte <= 23`)
+						})
+					})
+				})
+			})
+
+			Convey("When I add a new In statement", func() {
+
+				f.WithKey("in").In("a", "b", "c")
+
+				Convey("Then the filter should be correctly populated", func() {
+					So(f.keys, ShouldResemble, FilterKeys{
+						"hello",
+						"in",
+					})
+					So(f.Values(), ShouldResemble, FilterValues{
+						FilterValue{1},
+						FilterValue{"a", "b", "c"},
+					})
+					So(f.Operators(), ShouldResemble, FilterOperators{
+						AndOperator,
+						AndOperator,
+					})
+					So(f.Comparators(), ShouldResemble, FilterComparators{
+						EqualComparator,
+						InComparator,
+					})
+
+					Convey("When I add a new Contains statement", func() {
+
+						f.WithKey("ctn").Contains(false)
+
+						Convey("Then the filter should be correctly populated", func() {
+							So(f.Keys(), ShouldResemble, FilterKeys{
+								"hello",
+								"in",
+								"ctn",
+							})
+							So(f.Values(), ShouldResemble, FilterValues{
+								FilterValue{1},
+								FilterValue{"a", "b", "c"},
+								FilterValue{false},
+							})
+							So(f.Operators(), ShouldResemble, FilterOperators{
+								AndOperator,
+								AndOperator,
+								AndOperator,
+							})
+							So(f.Comparators(), ShouldResemble, FilterComparators{
+								EqualComparator,
+								InComparator,
+								ContainComparator,
+							})
+
+							Convey("Then the string representation should be correct", func() {
+								So(f.String(), ShouldEqual, `hello == 1 and in in ["a", "b", "c"] and ctn contains [false]`)
+							})
+						})
+					})
+				})
+			})
+
+			Convey("When I add a new difference comparator", func() {
+				f.WithKey("x").NotEquals(true)
+
+				Convey("Then the filter should be correctly populated", func() {
+					So(f.keys, ShouldResemble, FilterKeys{
+						"hello",
+						"x",
+					})
+					So(f.Values(), ShouldResemble, FilterValues{
+						FilterValue{1},
+						FilterValue{true},
+					})
+					So(f.Operators(), ShouldResemble, FilterOperators{
+						AndOperator,
+						AndOperator,
+					})
+					So(f.Comparators(), ShouldResemble, FilterComparators{
+						EqualComparator,
+						NotEqualComparator,
+					})
+					So(f.String(), ShouldEqual, `hello == 1 and x != true`)
+				})
+			})
+		})
+	})
+}
+
+func TestFilter_AppendToExisting(t *testing.T) {
+
+	Convey("Given I have a simple filter", t, func() {
+
+		f := NewFilterComposer().WithKey("a").Equals("b").Done()
+
+		Convey("When I append mode", func() {
+
+			f = f.WithKey("b").Equals("c").Done()
+
+			Convey("Then f should be correct", func() {
+				So(f.String(), ShouldEqual, `a == "b" and b == "c"`)
+			})
+		})
+	})
+
+	Convey("Given I have a composed filter", t, func() {
+
+		f := NewFilterComposer().And(
+			NewFilterComposer().WithKey("a").Equals("b").Done(),
+		).Done()
+
+		Convey("When I append mode", func() {
+
+			f = f.WithKey("b").Equals("c").Done()
+
+			Convey("Then f should be correct", func() {
+				So(f.String(), ShouldEqual, `((a == "b")) and b == "c"`)
+			})
+		})
+	})
+}
+
+func TestFilter_Date(t *testing.T) {
+
+	Convey("Given I have a filter with date", t, func() {
+
+		f := NewFilterComposer().WithKey("date").Equals(time.Time{}).Done()
+
+		Convey("When I call String", func() {
+
+			s := f.String()
+
+			Convey("Then the string should be correct", func() {
+				So(s, ShouldEqual, `date == date("0001-01-01T00:00:00Z")`)
+			})
+		})
+	})
+
+	Convey("Given I have a filter with duration", t, func() {
+
+		f := NewFilterComposer().WithKey("duration").Equals(-2 * time.Second).Done()
+
+		Convey("When I call String", func() {
+
+			s := f.String()
+
+			Convey("Then the string should be correct", func() {
+				So(s, ShouldEqual, `duration == now("-2s")`)
+			})
+		})
+	})
+}
+
+func TestFilter_SubFilters(t *testing.T) {
+
+	Convey("Given I have a composed filters", t, func() {
+
+		f := NewFilterComposer().
+			WithKey("namespace").Equals("coucou").
+			WithKey("number").Equals(32.9).
+			And(
+				NewFilterComposer().
+					WithKey("name").Equals("toto").
+					WithKey("value").Equals(1).
+					Done(),
+				NewFilterComposer().
+					WithKey("color").Contains("red", "green", "blue", 43).
+					WithKey("something").NotContains("stuff").
+					Or(
+						NewFilterComposer().
+							WithKey("size").Matches(".*").
+							Done(),
+						NewFilterComposer().
+							WithKey("size").Equals("medium").
+							WithKey("fat").Equals(false).
+							Done(),
+						NewFilterComposer().
+							WithKey("size").In(true, false).
+							WithKey("size").NotIn(1).
+							Done(),
+					).
+					Done(),
+			).
+			Done()
+
+		Convey("When I call string it should be correct ", func() {
+			So(f.String(), ShouldEqual, `namespace == "coucou" and number == 32.900000 and ((name == "toto" and value == 1) and (color contains ["red", "green", "blue", 43] and something not contains "stuff" or ((size matches [".*"]) or (size == "medium" and fat == false) or (size in [true, false] and size not in 1))))`)
+		})
+	})
+}
+
+func TestFilter_Exists(t *testing.T) {
+
+	Convey("Given I create a filter", t, func() {
+
+		f := NewFilterComposer().WithKey("key1").Exists().WithKey("key2").NotExists().Done()
+
+		Convey("When I call string it should be correct ", func() {
+			So(f.String(), ShouldEqual, "key1 exists and key2 not exists")
+		})
+	})
+}

--- a/filterparser.go
+++ b/filterparser.go
@@ -1,0 +1,724 @@
+// Copyright 2019 Aporeto Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elemental
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type checkRuneFunc = func(ch rune) bool
+
+type parserToken int
+
+const (
+	parserTokenILLEGAL parserToken = iota
+	parserTokenEOF
+	parserTokenWHITESPACE
+	parserTokenWORD
+	parserTokenLEFTPARENTHESE
+	parserTokenRIGHTPARENTHESE
+	parserTokenAND
+	parserTokenOR
+	parserTokenQUOTE
+	parserTokenSINGLEQUOTE
+	parserTokenEQUAL
+	parserTokenNOTEQUAL
+	parserTokenLT
+	parserTokenLTE
+	parserTokenGT
+	parserTokenGTE
+	parserTokenCONTAINS
+	parserTokenMATCHES
+	parserTokenTRUE
+	parserTokenFALSE
+	parserTokenLEFTSQUAREPARENTHESE
+	parserTokenRIGHTSQUAREPARENTHESE
+	parserTokenCOMMA
+	parserTokenNOTCONTAINS
+	// parserTokenNOTMATCHES not implemented yet in filters.
+	parserTokenIN
+	parserTokenNOTIN
+	parserTokenNOT
+	parserTokenEXISTS
+	parserTokenNOTEXISTS
+)
+
+const (
+	wordAND         = "AND"
+	wordCONTAINS    = "CONTAINS"
+	wordEQUAL       = "=="
+	wordFALSE       = "FALSE"
+	wordGT          = ">"
+	wordGTE         = ">="
+	wordIN          = "IN"
+	wordLT          = "<"
+	wordLTE         = "<="
+	wordMATCHES     = "MATCHES"
+	wordNOTCONTAINS = "NOT CONTAINS"
+	wordNOTEQUAL    = "!="
+	wordNOTIN       = "NOT IN"
+	wordOR          = "OR"
+	wordTRUE        = "TRUE"
+	wordNOT         = "NOT"
+	wordEXISTS      = "EXISTS"
+	wordNOTEXISTS   = "NOTEXISTS"
+	wordEOF         = "EOF"
+)
+
+const (
+	runeEOF                   = rune(0)
+	runeLEFTPARENTHESE        = '('
+	runeRIGHTPARENTHESE       = ')'
+	runeQUOTE                 = '"'
+	runeSINGLEQUOTE           = '\''
+	runeLEFTSQUAREPARENTHESE  = '['
+	runeRIGHTSQUAREPARENTHESE = ']'
+	runeCOMMA                 = ','
+)
+
+var specialLetters = map[rune]interface{}{
+	'-':  nil,
+	'_':  nil,
+	'@':  nil,
+	':':  nil,
+	'$':  nil,
+	'#':  nil,
+	'.':  nil,
+	'/':  nil,
+	'\\': nil,
+	'*':  nil,
+}
+
+var operatorStart = map[rune]interface{}{
+	'<': nil,
+	'>': nil,
+	'=': nil,
+	'!': nil,
+}
+
+var operatorsToToken = map[string]parserToken{
+	wordEQUAL:       parserTokenEQUAL,
+	wordNOTEQUAL:    parserTokenNOTEQUAL,
+	wordLT:          parserTokenLT,
+	wordLTE:         parserTokenLTE,
+	wordGT:          parserTokenGT,
+	wordGTE:         parserTokenGTE,
+	wordCONTAINS:    parserTokenCONTAINS,
+	wordNOTCONTAINS: parserTokenNOTCONTAINS,
+	wordMATCHES:     parserTokenMATCHES,
+	wordIN:          parserTokenIN,
+	wordNOTIN:       parserTokenNOTIN,
+	wordNOT:         parserTokenNOT,
+	wordEXISTS:      parserTokenEXISTS,
+	wordNOTEXISTS:   parserTokenNOTEXISTS,
+}
+
+var wordToToken = map[string]parserToken{
+	wordAND:   parserTokenAND,
+	wordOR:    parserTokenOR,
+	wordTRUE:  parserTokenTRUE,
+	wordFALSE: parserTokenFALSE,
+}
+
+var runeToToken = map[rune]parserToken{
+	runeEOF:                   parserTokenEOF,
+	runeLEFTPARENTHESE:        parserTokenLEFTPARENTHESE,
+	runeRIGHTPARENTHESE:       parserTokenRIGHTPARENTHESE,
+	runeQUOTE:                 parserTokenQUOTE,
+	runeSINGLEQUOTE:           parserTokenSINGLEQUOTE,
+	runeLEFTSQUAREPARENTHESE:  parserTokenLEFTSQUAREPARENTHESE,
+	runeRIGHTSQUAREPARENTHESE: parserTokenRIGHTSQUAREPARENTHESE,
+	runeCOMMA:                 parserTokenCOMMA,
+}
+
+var datePattern = regexp.MustCompile(`^date\((.*)\)$`)
+var nowPattern = regexp.MustCompile(`^now\((.*)\)$`)
+var dateLayout = "2006-01-02"
+var dateTimeLayout = "2006-01-02 15:04"
+var errorInvalidExpression = fmt.Errorf("invalid expression")
+
+// FilterParser represents a Parser
+type FilterParser struct {
+	scanner *scanner
+	buffer  struct {
+		token   parserToken // last read token
+		literal string      // last read literal
+		size    int         // buffer size (max=1)
+	}
+}
+
+// NewFilterParser returns an instance of FilterParser for the given input
+func NewFilterParser(input string) *FilterParser {
+	return &FilterParser{
+		scanner: newScanner(input),
+	}
+}
+
+// Parse parses the input string and returns a new Filter.
+func (p *FilterParser) Parse() (*Filter, error) {
+
+	token, literal := p.peekIgnoreWhitespace()
+
+	// The input needs to start with a word, a quote or a left parenthese.
+	if token != parserTokenWORD &&
+		token != parserTokenQUOTE &&
+		token != parserTokenSINGLEQUOTE &&
+		token != parserTokenLEFTPARENTHESE {
+		return nil, fmt.Errorf("invalid start of expression. found %s", literal)
+	}
+
+	// Stack all discovered the filters
+	var stack []*Filter
+	// Default conjunction is an and.
+	var conjunction parserToken = -1
+
+	finalFilter := NewFilterComposer()
+	for {
+		token, literal := p.scanIgnoreWhitespace()
+
+		if token == parserTokenEOF || token == parserTokenRIGHTPARENTHESE {
+			// In case of EOF or ")", we need to finalize the filter.
+
+			switch len(stack) {
+			case 0:
+				// Nothing to do here.
+			case 1:
+				// No specific combination
+				finalFilter = stack[0]
+			default:
+				// Combination depending on the conjunction
+				if conjunction == parserTokenOR {
+					finalFilter.Or(stack...)
+				} else {
+					finalFilter.And(stack...)
+				}
+			}
+			break
+		}
+
+		if token == parserTokenQUOTE || token == parserTokenSINGLEQUOTE {
+			// Handle expression starting with QUOTE like "a" operator b
+			key, err := p.parseUntilQuoteSimilar(token)
+			if err != nil {
+				return nil, err
+			}
+
+			operator, value, err := p.parseOperatorAndValue()
+			if err != nil {
+				return nil, err
+			}
+
+			filter, err := p.makeFilter(key, operator, value)
+			if err != nil {
+				return nil, err
+			}
+
+			stack = append(stack, filter)
+			continue
+		}
+
+		if token == parserTokenWORD {
+			// Handle expression without QUOTE like a operator b
+			// In that case, the literal is the word scanned.
+			operator, value, err := p.parseOperatorAndValue()
+			if err != nil {
+				return nil, err
+			}
+
+			filter, err := p.makeFilter(literal, operator, value)
+			if err != nil {
+				return nil, err
+			}
+
+			stack = append(stack, filter)
+			continue
+		}
+
+		if token == parserTokenAND {
+			// Switch the conjunction to an AND
+			if conjunction != -1 && conjunction == parserTokenOR && len(stack) > 1 {
+				filter := NewFilterComposer().Or(stack...).Done()
+				stack = []*Filter{filter}
+			}
+			conjunction = token
+			continue
+		}
+
+		if token == parserTokenOR {
+			// Switch the conjunction to an OR
+			if conjunction != -1 && conjunction == parserTokenAND && len(stack) > 1 {
+				filter := NewFilterComposer().And(stack...).Done()
+				stack = []*Filter{filter}
+			}
+			conjunction = token
+			continue
+		}
+
+		if token == parserTokenLEFTPARENTHESE {
+			// In case of "(", a subfilter needs to be computed
+			// and stacked to the previously found filters.
+
+			subFilter, err := p.Parse()
+			if err != nil {
+				return nil, err
+			}
+			stack = append(stack, subFilter)
+		}
+	}
+
+	return finalFilter.Done(), nil
+}
+
+// scan returns the next token scanned or the last bufferred one
+func (p *FilterParser) scan() (parserToken, string) {
+	// If a token has been buffered, use it
+	if p.buffer.size != 0 {
+		p.buffer.size = 0
+		return p.buffer.token, p.buffer.literal
+	}
+
+	// Otherwise scan the next token
+	token, literal := p.scanner.scan()
+
+	// Save it to the buffer in case we unscan later.
+	p.buffer.token, p.buffer.literal = token, literal
+
+	return token, literal
+}
+
+// unscan put back the token into the buffer.
+func (p *FilterParser) unscan() {
+	p.buffer.size = 1
+}
+
+// peekIgnoreWhitespace scans to the next whitespace and unscan it
+func (p *FilterParser) peekIgnoreWhitespace() (tok parserToken, lit string) {
+
+	tok, lit = p.scanIgnoreWhitespace()
+	p.unscan()
+	return
+}
+
+// scanIgnoreWhitespace scans the next non-whitespace token.
+func (p *FilterParser) scanIgnoreWhitespace() (tok parserToken, lit string) {
+
+	tok, lit = p.scan()
+
+	if tok == parserTokenWHITESPACE {
+		tok, lit = p.scan()
+	}
+
+	return
+}
+
+func (p *FilterParser) parseOperatorAndValue() (parserToken, interface{}, error) {
+
+	operator, err := p.parseOperator()
+	if err != nil {
+		return parserTokenILLEGAL, nil, err
+	}
+
+	if operator == parserTokenEXISTS || operator == parserTokenNOTEXISTS {
+		return operator, nil, nil
+	}
+
+	value, err := p.parseValue()
+	if err != nil {
+		return parserTokenILLEGAL, nil, err
+	}
+
+	return operator, value, nil
+}
+
+func (p *FilterParser) makeFilter(key string, operator parserToken, value interface{}) (*Filter, error) {
+
+	if strings.HasPrefix(key, "$") {
+		return nil, fmt.Errorf("could not start a parameter with $. Found %s", key)
+	}
+
+	filter := NewFilterComposer()
+
+	// Create filter
+	switch operator {
+	case parserTokenEQUAL:
+		filter.WithKey(key).Equals(value)
+	case parserTokenNOTEQUAL:
+		filter.WithKey(key).NotEquals(value)
+	case parserTokenLT:
+		filter.WithKey(key).LesserThan(value)
+	case parserTokenLTE:
+		filter.WithKey(key).LesserOrEqualThan(value)
+	case parserTokenGT:
+		filter.WithKey(key).GreaterThan(value)
+	case parserTokenGTE:
+		filter.WithKey(key).GreaterOrEqualThan(value)
+	case parserTokenCONTAINS:
+		if values, ok := value.([]interface{}); ok {
+			filter.WithKey(key).Contains(values...)
+		} else {
+			filter.WithKey(key).Contains(value)
+		}
+	case parserTokenNOTCONTAINS:
+		if values, ok := value.([]interface{}); ok {
+			filter.WithKey(key).NotContains(values...)
+		} else {
+			filter.WithKey(key).NotContains(value)
+		}
+	case parserTokenIN:
+		if values, ok := value.([]interface{}); ok {
+			filter.WithKey(key).In(values...)
+		} else {
+			filter.WithKey(key).In(value)
+		}
+	case parserTokenNOTIN:
+		if values, ok := value.([]interface{}); ok {
+			filter.WithKey(key).NotIn(values...)
+		} else {
+			filter.WithKey(key).NotIn(value)
+		}
+	case parserTokenMATCHES:
+		if values, ok := value.([]interface{}); ok {
+			filter.WithKey(key).Matches(values...)
+		} else {
+			filter.WithKey(key).Matches(value)
+		}
+	case parserTokenEXISTS:
+		filter.WithKey(key).Exists()
+	case parserTokenNOTEXISTS:
+		filter.WithKey(key).NotExists()
+	default:
+		return nil, fmt.Errorf("unsupported operator")
+	}
+
+	token, literal := p.peekIgnoreWhitespace()
+	if token != parserTokenAND &&
+		token != parserTokenOR &&
+		token != parserTokenRIGHTPARENTHESE &&
+		token != parserTokenEOF {
+
+		if token == parserTokenEOF {
+			literal = wordEOF
+		}
+		return nil, fmt.Errorf("invalid keyword after %s. found %s", filter.Done().String(), literal)
+	}
+
+	return filter.Done(), nil
+}
+
+func (p *FilterParser) parseOperator() (parserToken, error) {
+
+	token, literal := p.scanIgnoreWhitespace()
+
+	operatorNot := false
+	if token == parserTokenNOT {
+		operatorNot = true
+		token, literal = p.scanIgnoreWhitespace()
+	}
+
+	if !tokenIsOperator(token) {
+		if token == parserTokenEOF {
+			literal = wordEOF
+		}
+
+		return parserTokenILLEGAL, fmt.Errorf("invalid operator. found %s instead of (==, !=, <, <=, >, >=, contains, in, matches, exists)", literal)
+	}
+
+	if operatorNot {
+		switch token {
+		case parserTokenCONTAINS:
+			return parserTokenNOTCONTAINS, nil
+		case parserTokenIN:
+			return parserTokenNOTIN, nil
+		case parserTokenEXISTS:
+			return parserTokenNOTEXISTS, nil
+		default:
+			return parserTokenILLEGAL, fmt.Errorf("invalid usage of operator NOT before %s", literal)
+		}
+	}
+
+	return token, nil
+}
+
+func (p *FilterParser) parseValue() (interface{}, error) {
+
+	token, literal := p.scanIgnoreWhitespace()
+
+	if token == parserTokenQUOTE || token == parserTokenSINGLEQUOTE {
+		return p.parseStringValue()
+	}
+
+	if token == parserTokenLEFTSQUAREPARENTHESE {
+		return p.parseArrayValue()
+	}
+
+	if token == parserTokenTRUE {
+		return true, nil
+	}
+
+	if token == parserTokenFALSE {
+		return false, nil
+	}
+
+	if i, err := strconv.ParseInt(literal, 10, 0); err == nil {
+		return i, nil
+	}
+
+	if f, err := strconv.ParseFloat(literal, 0); err == nil {
+		return f, nil
+	}
+
+	datetime, err := p.parseDateValue()
+	if err == nil {
+		return datetime, nil
+	}
+	if err != errorInvalidExpression {
+		return nil, err
+	}
+
+	duration, err := p.parseDurationValue()
+	if err == nil {
+		return duration, nil
+	}
+	if err != errorInvalidExpression {
+		return nil, err
+	}
+
+	v, err := p.parseStringValue()
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// parseExpression parse an expression with the regex if the prefix matches and returns the matching value.
+func (p *FilterParser) parseExpression(prefix string, regex *regexp.Regexp) (string, error) {
+
+	p.unscan()
+	_, literal := p.scanIgnoreWhitespace()
+
+	if literal != prefix {
+		p.unscan()
+		return "", errorInvalidExpression
+	}
+
+	expression := literal
+	token, literal := p.scanIgnoreWhitespace()
+	if token != parserTokenLEFTPARENTHESE {
+		p.unscan()
+		return "", errorInvalidExpression
+	}
+
+	expression += literal
+	for { // Read the expression until the next )
+		token, literal = p.scan()
+		expression += literal
+
+		if token == parserTokenLEFTPARENTHESE ||
+			token == parserTokenEOF {
+			return "", errorInvalidExpression
+		}
+
+		if token == parserTokenRIGHTPARENTHESE {
+			break
+		}
+	}
+
+	matches := regex.FindStringSubmatch(expression)
+	if len(matches) != 2 {
+		return "", errorInvalidExpression
+	}
+
+	return strings.Trim(matches[1], " \""), nil
+}
+
+func (p *FilterParser) parseDurationValue() (time.Duration, error) {
+
+	expression, err := p.parseExpression("now", nowPattern)
+	if err != nil {
+		return -1, err
+	}
+
+	if expression == "" {
+		return time.Duration(0), nil
+	}
+
+	d, err := time.ParseDuration(expression)
+	if err != nil {
+		return -1, fmt.Errorf("unable to parse duration %s: %s", expression, err.Error())
+	}
+	return d, nil
+}
+
+func (p *FilterParser) parseDateValue() (time.Time, error) {
+
+	expression, err := p.parseExpression("date", datePattern)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// RFC3339 Layout
+	t, err := time.Parse(time.RFC3339, expression)
+	if err == nil {
+		return t, nil
+	}
+	// YYYY-MM-DD HH:MM Layout
+	t, err = time.Parse(dateTimeLayout, expression)
+	if err == nil {
+		return t, nil
+	}
+	// YYYY-MM-DD Layout
+	t, err = time.Parse(dateLayout, expression)
+	if err == nil {
+		return t, nil
+	}
+
+	return t, fmt.Errorf("unable to parse date format %s", expression)
+}
+
+func (p *FilterParser) parseUntilQuoteSimilar(tokenQuote parserToken) (string, error) {
+
+	var word string
+	// Scan everything until the next quote or the end of the input
+	for {
+		token, literal := p.scan()
+		if token == parserTokenEOF {
+			return "", fmt.Errorf("missing quote after %s", word)
+		}
+
+		if token == tokenQuote {
+			return word, nil
+		}
+
+		// Add anything to the value
+		word += literal
+	}
+}
+
+func (p *FilterParser) parseStringValue() (string, error) {
+
+	p.unscan()
+	token, literal := p.scanIgnoreWhitespace()
+
+	// Quoted string
+	if token == parserTokenQUOTE || token == parserTokenSINGLEQUOTE {
+		return p.parseUntilQuoteSimilar(token)
+	}
+
+	// Unquoted string can have only one word
+	if token != parserTokenWORD {
+		if token == parserTokenEOF {
+			literal = wordEOF
+		}
+		return "", fmt.Errorf("invalid value. found %s", literal)
+	}
+
+	token, next := p.peekIgnoreWhitespace()
+	switch token {
+	case parserTokenQUOTE, parserTokenSINGLEQUOTE:
+		return "", fmt.Errorf("missing quote before the value: %s", literal)
+	case parserTokenWORD:
+		return "", fmt.Errorf("missing parenthese to protect value: %s %s", literal, next)
+	}
+
+	return literal, nil
+}
+
+func (p *FilterParser) parseArrayValue() ([]interface{}, error) {
+
+	p.unscan()
+
+	token, literal := p.scanIgnoreWhitespace()
+	if token != parserTokenLEFTSQUAREPARENTHESE {
+		return nil, fmt.Errorf("invalid start of list. found %s", literal)
+	}
+
+	values := []interface{}{}
+
+	for {
+
+		token, literal := p.scanIgnoreWhitespace()
+
+		if token == parserTokenEOF ||
+			token == parserTokenLEFTPARENTHESE ||
+			token == parserTokenRIGHTPARENTHESE {
+			return nil, fmt.Errorf("invalid end of array. found %s", literal)
+		}
+
+		if token == parserTokenRIGHTSQUAREPARENTHESE {
+			break
+		}
+
+		if token == parserTokenCOMMA {
+			continue
+		}
+
+		p.unscan()
+		value, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+
+		values = append(values, value)
+	}
+
+	return values, nil
+}
+
+func isWhitespace(ch rune) bool { return ch == ' ' || ch == '\t' || ch == '\n' }
+func isDigit(ch rune) bool      { return (ch >= '0' && ch <= '9') }
+func isLetter(ch rune) bool {
+
+	if _, ok := specialLetters[ch]; ok {
+		return true
+	}
+
+	if _, ok := operatorStart[ch]; ok {
+		return true
+	}
+
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+}
+
+func isOperatorStart(ch rune) bool {
+
+	_, ok := operatorStart[ch]
+	return ok
+}
+
+func isOperator(runes ...rune) (parserToken, string, bool) {
+	word := string(runes)
+	token, ok := operatorsToToken[word]
+
+	return token, word, ok
+}
+
+func tokenIsOperator(token parserToken) bool {
+
+	return token == parserTokenEQUAL ||
+		token == parserTokenNOTEQUAL ||
+		token == parserTokenLT ||
+		token == parserTokenLTE ||
+		token == parserTokenGT ||
+		token == parserTokenGTE ||
+		token == parserTokenCONTAINS ||
+		token == parserTokenIN ||
+		token == parserTokenMATCHES ||
+		token == parserTokenEXISTS ||
+		token == parserTokenNOTEXISTS ||
+		token == parserTokenNOTCONTAINS ||
+		token == parserTokenNOTIN
+}

--- a/filterparser_test.go
+++ b/filterparser_test.go
@@ -1,0 +1,1306 @@
+// Copyright 2019 Aporeto Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elemental
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestParser_Spaces(t *testing.T) {
+
+	Convey("Given the operator '==' is not separated by spaces but quoted", t, func() {
+
+		parser := NewFilterParser(`"tag"=="@sys:image=nginx"`)
+		expectedFilter := NewFilterComposer().WithKey("tag").Equals("@sys:image=nginx").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator '==' is not separated by spaces", t, func() {
+
+		parser := NewFilterParser(`a==b`)
+		expectedFilter := NewFilterComposer().WithKey("a").Equals("b").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator '<=' is not separated by spaces", t, func() {
+
+		parser := NewFilterParser(`a<=b`)
+		expectedFilter := NewFilterComposer().WithKey("a").LesserOrEqualThan("b").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator '<' is not separated by spaces", t, func() {
+
+		parser := NewFilterParser(`a<b`)
+		expectedFilter := NewFilterComposer().WithKey("a").LesserThan("b").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator is separated by spaces", t, func() {
+
+		parser := NewFilterParser(`a == b`)
+		expectedFilter := NewFilterComposer().WithKey("a").Equals("b").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator complex value", t, func() {
+
+		parser := NewFilterParser(`value == "age>=3"`)
+		expectedFilter := NewFilterComposer().WithKey("value").Equals("age>=3").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator complex key", t, func() {
+
+		parser := NewFilterParser(`"tag==toto"=="3==5"`)
+		expectedFilter := NewFilterComposer().WithKey("tag==toto").Equals("3==5").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the weird case '"=="=="=="'`, t, func() {
+
+		parser := NewFilterParser(`"=="=="=="`)
+		expectedFilter := NewFilterComposer().WithKey("==").Equals("==").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the weird case '"=="    ==    "=="'`, t, func() {
+
+		parser := NewFilterParser(`"=="    ==    "=="`)
+		expectedFilter := NewFilterComposer().WithKey("==").Equals("==").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+}
+
+func TestParser_Keys(t *testing.T) {
+
+	Convey("Given the quoted expression", t, func() {
+
+		parser := NewFilterParser("\"key\" == value")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("value").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the unquoted expression", t, func() {
+
+		parser := NewFilterParser("key == value")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("value").Done()
+
+		Convey("When I run Parse", func() {
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the expression contains digits", t, func() {
+
+		parser := NewFilterParser("key1234 == value")
+		expectedFilter := NewFilterComposer().WithKey("key1234").Equals("value").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the expression is a tag like '@sys:usr:key'", t, func() {
+
+		parser := NewFilterParser("@sys:usr:key == value")
+		expectedFilter := NewFilterComposer().WithKey("@sys:usr:key").Equals("value").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the expression is a tag like '$key'", t, func() {
+
+		parser := NewFilterParser("$key == value")
+		// expectedFilter := NewFilterComposer().WithKey("$key").Equals("value").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should have an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldContainSubstring, "could not start a parameter with $")
+				So(filter, ShouldEqual, nil)
+			})
+		})
+	})
+
+}
+func TestParser_Keys_Errors(t *testing.T) {
+
+	Convey(`Given the expression: "key`, t, func() {
+
+		parser := NewFilterParser(`"key == chris`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote after key == chris`)
+			})
+		})
+	})
+}
+
+func TestParser_Operators(t *testing.T) {
+
+	Convey("Given the operator: '=='", t, func() {
+
+		parser := NewFilterParser("key == value")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("value").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator '!='", t, func() {
+
+		parser := NewFilterParser("key != value")
+		expectedFilter := NewFilterComposer().WithKey("key").NotEquals("value").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'contains'", t, func() {
+
+		parser := NewFilterParser(`key contains ["value1", "value2"]`)
+		expectedFilter := NewFilterComposer().WithKey("key").Contains("value1", "value2").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'not contains'", t, func() {
+
+		parser := NewFilterParser(`key not contains ["value1", "value2"]`)
+		expectedFilter := NewFilterComposer().WithKey("key").NotContains("value1", "value2").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'in'", t, func() {
+
+		parser := NewFilterParser(`key in ["value1", "value2"]`)
+		expectedFilter := NewFilterComposer().WithKey("key").In("value1", "value2").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'not in'", t, func() {
+
+		parser := NewFilterParser(`key not in ["value1", "value2"]`)
+		expectedFilter := NewFilterComposer().WithKey("key").NotIn("value1", "value2").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'matches'", t, func() {
+
+		parser := NewFilterParser(`key matches ["value1", "value2"]`)
+		expectedFilter := NewFilterComposer().WithKey("key").Matches("value1", "value2").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'exists'", t, func() {
+
+		parser := NewFilterParser(`key exists`)
+		expectedFilter := NewFilterComposer().WithKey("key").Exists().Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the operator 'not exists'", t, func() {
+
+		parser := NewFilterParser(`key not exists`)
+		expectedFilter := NewFilterComposer().WithKey("key").NotExists().Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+}
+
+func TestParser_Operators_Errors(t *testing.T) {
+
+	Convey(`Given the wrong operator '"'`, t, func() {
+
+		parser := NewFilterParser(`key" == chris`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `invalid operator. found " instead of (==, !=, <, <=, >, >=, contains, in, matches, exists)`)
+			})
+		})
+	})
+
+	Convey(`Given the wrong operator 'and'`, t, func() {
+
+		parser := NewFilterParser(`key and chris`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `invalid operator. found and instead of (==, !=, <, <=, >, >=, contains, in, matches, exists)`)
+			})
+		})
+	})
+
+	Convey(`Given the wrong operator: name == 0 and toto contains "1" an contains "@hello=2"`, t, func() {
+
+		parser := NewFilterParser(`name == 0 and toto contains "1" an contains "@hello=2"`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldContainSubstring, `invalid keyword after toto contains ["1"]. found an`)
+			})
+		})
+	})
+
+}
+
+func TestParser_Values_StringType(t *testing.T) {
+
+	Convey("Given the string value: '\"hello world\"'", t, func() {
+
+		parser := NewFilterParser("key == \"hello world\"")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("hello world").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the string value with single quote: 'hello world'", t, func() {
+
+		parser := NewFilterParser("key == 'hello world'")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("hello world").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the string value: '\"hello\"word\"'", t, func() {
+
+		parser := NewFilterParser("key == \"hello\\\"world\"")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("hello\"world").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the string value: 'hello\\'word'", t, func() {
+
+		parser := NewFilterParser("key == 'hello\\'world'")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("hello'world").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the string value: 'hello\\ word'", t, func() {
+
+		parser := NewFilterParser("key == hello\\ world")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("hello world").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the string value: 'nowadays'", t, func() {
+
+		parser := NewFilterParser("key == nowadays")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("nowadays").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the string value: 'datetime'", t, func() {
+
+		parser := NewFilterParser("key == datetime")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("datetime").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+}
+
+func TestParser_Values_Errors(t *testing.T) {
+
+	Convey("Given the string value: 'hello word'", t, func() {
+
+		parser := NewFilterParser("key == hello world")
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, "missing parenthese to protect value: hello world")
+			})
+		})
+	})
+
+	Convey(`Given the string value: 'key == "hello'`, t, func() {
+
+		parser := NewFilterParser(`key == "hello`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote after hello`)
+			})
+		})
+	})
+
+	Convey(`Given the single quoted string value: key == 'hello`, t, func() {
+
+		parser := NewFilterParser(`key == 'hello`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote after hello`)
+			})
+		})
+	})
+
+	Convey(`Given the string value: key == hello"`, t, func() {
+
+		parser := NewFilterParser(`key == hello"`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote before the value: hello`)
+			})
+		})
+	})
+	Convey(`Given the string value: key == hello'`, t, func() {
+
+		parser := NewFilterParser(`key == hello'`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote before the value: hello`)
+			})
+		})
+	})
+
+	Convey(`Given the string value: key == 'hello"`, t, func() {
+
+		parser := NewFilterParser(`key == 'hello"`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote after hello"`)
+			})
+		})
+	})
+
+	Convey(`Given the string value: key == "hello'`, t, func() {
+
+		parser := NewFilterParser(`key == "hello'`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `missing quote after hello'`)
+			})
+		})
+	})
+
+	Convey(`Given the wrong value and: key == and"`, t, func() {
+
+		parser := NewFilterParser(`key == and"`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `invalid value. found and`)
+			})
+		})
+	})
+
+	Convey(`Given the wrong value and: key exists value"`, t, func() {
+
+		parser := NewFilterParser(`key exists value"`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `invalid keyword after key exists. found value`)
+			})
+		})
+	})
+
+}
+
+func TestParser_Values_BoolType(t *testing.T) {
+	Convey("Given the boolean value: 'true'", t, func() {
+
+		parser := NewFilterParser("key == true")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals(true).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the boolean value: 'false'", t, func() {
+
+		parser := NewFilterParser("key == false")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals(false).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the boolean value: '\"true\"'", t, func() {
+
+		parser := NewFilterParser("key == \"true\"")
+		expectedFilter := NewFilterComposer().WithKey("key").Equals("true").Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+}
+
+func TestParser_Values_DateType(t *testing.T) {
+	Convey("Given the date value: '2018-04-26'", t, func() {
+		parser := NewFilterParser(`key == date("2018-04-26")`)
+		expectedValue := time.Date(2018, time.April, 26, 0, 0, 0, 0, time.UTC)
+		expectedFilter := NewFilterComposer().WithKey("key").Equals(expectedValue).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the date value: '2018-04-26 23:50'", t, func() {
+		parser := NewFilterParser(`key == date("2018-04-26 23:50")`)
+		expectedValue := time.Date(2018, time.April, 26, 23, 50, 0, 0, time.UTC)
+		expectedFilter := NewFilterComposer().WithKey("key").Equals(expectedValue).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the date value: '2018-04-26T23:50:30.0Z'", t, func() {
+		parser := NewFilterParser(`key > date("2018-04-26T23:50:30.0Z")`)
+		expectedValue := time.Date(2018, time.April, 26, 23, 50, 30, 0, time.UTC)
+		expectedFilter := NewFilterComposer().WithKey("key").GreaterThan(expectedValue).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+}
+
+func TestParser_Values_DateType_Errors(t *testing.T) {
+
+	Convey("Given the invalid date: 'invalid-date'", t, func() {
+		parser := NewFilterParser(`key == date("invalid-date")`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `unable to parse date format invalid-date`)
+			})
+		})
+	})
+
+	Convey("Given the invalid date: '2012-24-2'", t, func() {
+		parser := NewFilterParser(`key == date("2012-24-2")`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `unable to parse date format 2012-24-2`)
+			})
+		})
+	})
+
+	Convey("Given the invalid date: '2012-24-2' (missing quote)", t, func() {
+		parser := NewFilterParser(`key == date(2012-24-2")`)
+
+		Convey("When I run Parse", func() {
+
+			_, err := parser.Parse()
+
+			Convey("Then there should be an error", func() {
+				So(err, ShouldNotEqual, nil)
+				So(err.Error(), ShouldEqual, `unable to parse date format 2012-24-2`)
+			})
+		})
+	})
+}
+
+func TestParser_Values_DurationType(t *testing.T) {
+	Convey("Given the duration value: 'now()'", t, func() {
+		parser := NewFilterParser(`key == now()`)
+		expectedValue := time.Duration(0)
+		expectedFilter := NewFilterComposer().WithKey("key").Equals(expectedValue).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the duration value: '-1h'", t, func() {
+		parser := NewFilterParser(`key == now("-1h")`)
+		expectedValue := -1 * time.Hour
+		expectedFilter := NewFilterComposer().WithKey("key").Equals(expectedValue).Done()
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+}
+
+func Test_Parser(t *testing.T) {
+
+	Convey("Given the filter: namespace == chris and test == true", t, func() {
+
+		parser := NewFilterParser("namespace == chris and test == true")
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().WithKey("namespace").Equals("chris").Done(),
+				NewFilterComposer().WithKey("test").Equals(true).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the filter: namespace == chris and test == true or value > 30", t, func() {
+
+		parser := NewFilterParser("namespace == chris and test == true or value > 30")
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().Or(
+				NewFilterComposer().And(
+					NewFilterComposer().WithKey("namespace").Equals("chris").Done(),
+					NewFilterComposer().WithKey("test").Equals(true).Done(),
+				).Done(),
+				NewFilterComposer().WithKey("value").GreaterThan(30).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey("Given the filter: namespace == chris or test == true and value > 30", t, func() {
+
+		parser := NewFilterParser("namespace == chris or test == true and value > 30")
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().Or(
+					NewFilterComposer().WithKey("namespace").Equals("chris").Done(),
+					NewFilterComposer().WithKey("test").Equals(true).Done(),
+				).Done(),
+				NewFilterComposer().WithKey("value").GreaterThan(30).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: "namespace"=="chris" and "test"== true`, t, func() {
+
+		parser := NewFilterParser(`"namespace"=="chris" and "test"== true`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().WithKey("namespace").Equals("chris").Done(),
+				NewFilterComposer().WithKey("test").Equals(true).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: "namespace" == "chris" and "test" == true and date > date("2016-03-12")`, t, func() {
+
+		parser := NewFilterParser(`"namespace" == "chris" and "test" == true and date > date("2016-03-12")`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().WithKey("namespace").Equals("chris").Done(),
+				NewFilterComposer().WithKey("test").Equals(true).Done(),
+				NewFilterComposer().WithKey("date").GreaterThan(time.Date(2016, time.March, 12, 0, 0, 0, 0, time.UTC)).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: "age" <= 32 or "age" > 50`, t, func() {
+
+		parser := NewFilterParser(`"age" <= 32 or "age" > 50`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().Or(
+				NewFilterComposer().WithKey("age").LesserOrEqualThan(32).Done(),
+				NewFilterComposer().WithKey("age").GreaterThan(50).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: "age" < 32 or "age" >= 50`, t, func() {
+
+		parser := NewFilterParser(`"age" < 32 or "age" >= 50`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().Or(
+				NewFilterComposer().WithKey("age").LesserThan(32).Done(),
+				NewFilterComposer().WithKey("age").GreaterOrEqualThan(50).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: ("file" matches "*.txt" and "file" contains "search")`, t, func() {
+
+		parser := NewFilterParser(`("file" matches "*.txt" and "file" contains "search")`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().WithKey("file").Matches("*.txt").Done(),
+				NewFilterComposer().WithKey("file").Contains("search").Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: "namespace" == "/chris"`, t, func() {
+
+		parser := NewFilterParser(`"namespace" == "/chris"`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().WithKey("namespace").Equals("/chris").Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+
+	})
+
+	Convey(`Given the filter: "namespace" == "/chris" and test == true and ("name" == toto or "name" == tata)`, t, func() {
+
+		parser := NewFilterParser(`"namespace" == "/chris" and test == true and ("name" == toto or "name" == tata)`)
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().WithKey("namespace").Equals("/chris").Done(),
+				NewFilterComposer().WithKey("test").Equals(true).Done(),
+				NewFilterComposer().Or(
+					NewFilterComposer().WithKey("name").Equals("toto").Done(),
+					NewFilterComposer().WithKey("name").Equals("tata").Done(),
+				).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: (name == toto or name == tata) and age exists and age == 31`, t, func() {
+
+		parser := NewFilterParser("(name == toto or name == tata) and age exists and age == 31")
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().Or(
+					NewFilterComposer().WithKey("name").Equals("toto").Done(),
+					NewFilterComposer().WithKey("name").Equals("tata").Done(),
+				).Done(),
+				NewFilterComposer().WithKey("age").Exists().Done(),
+				NewFilterComposer().WithKey("age").Equals(31).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: (name == toto and name == tata) or (age == 31 and age == 32)`, t, func() {
+
+		parser := NewFilterParser("(name == toto and name == tata) or (age == 31 and age == 32)")
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().Or(
+				NewFilterComposer().And(
+					NewFilterComposer().WithKey("name").Equals("toto").Done(),
+					NewFilterComposer().WithKey("name").Equals("tata").Done(),
+				).Done(),
+				NewFilterComposer().And(
+					NewFilterComposer().WithKey("age").Equals(31).Done(),
+					NewFilterComposer().WithKey("age").Equals(32).Done(),
+				).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+	Convey(`Given the filter: name == toto and value == 38.9000 and ((name == toto and name == tata) or (age == 31 and age == 32) or protected in [true, false])`, t, func() {
+
+		parser := NewFilterParser("name == toto and value == 38.9000 and ((name == toto and name == tata) or (age == 31 and age == 32) or protected in [true, false])")
+
+		Convey("When I run Parse", func() {
+
+			filter, err := parser.Parse()
+			expectedFilter := NewFilterComposer().And(
+				NewFilterComposer().WithKey("name").Equals("toto").Done(),
+				NewFilterComposer().WithKey("value").Equals(38.9).Done(),
+				NewFilterComposer().Or(
+					NewFilterComposer().And(
+						NewFilterComposer().WithKey("name").Equals("toto").Done(),
+						NewFilterComposer().WithKey("name").Equals("tata").Done(),
+					).Done(),
+					NewFilterComposer().And(
+						NewFilterComposer().WithKey("age").Equals(31).Done(),
+						NewFilterComposer().WithKey("age").Equals(32).Done(),
+					).Done(),
+					NewFilterComposer().WithKey("protected").In(true, false).Done(),
+				).Done(),
+			).Done()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+	})
+
+}
+
+func TestParser_AdvancedFilter(t *testing.T) {
+
+	advancedFilter := `"namespace" == "coucou" and "number" == 32.900000 and (("name" == "toto" and "value" == 1) and ("color" contains ["red", "green", "blue", 43] and "something" in ["stuff"] or (("size" matches [".*"]) or ("size" == "medium" and "fat" == false) or ("size" in [true, false]))))`
+
+	Convey(`Given I have an advanced complex filter and a parser`, t, func() {
+
+		parser := NewFilterParser(advancedFilter)
+		expectedFilter := NewFilterComposer().And(
+			NewFilterComposer().WithKey("namespace").Equals("coucou").Done(),
+			NewFilterComposer().WithKey("number").Equals(32.9).Done(),
+			NewFilterComposer().And(
+
+				NewFilterComposer().And(
+					NewFilterComposer().WithKey("name").Equals("toto").Done(),
+					NewFilterComposer().WithKey("value").Equals(1).Done(),
+				).Done(),
+
+				NewFilterComposer().Or(
+					NewFilterComposer().And(
+						NewFilterComposer().WithKey("color").Contains("red", "green", "blue", 43).Done(),
+						NewFilterComposer().WithKey("something").In("stuff").Done(),
+					).Done(),
+
+					NewFilterComposer().Or(
+						NewFilterComposer().WithKey("size").Matches(".*").Done(),
+						NewFilterComposer().And(
+							NewFilterComposer().WithKey("size").Equals("medium").Done(),
+							NewFilterComposer().WithKey("fat").Equals(false).Done(),
+						).Done(),
+						NewFilterComposer().
+							WithKey("size").In(true, false).
+							Done(),
+					).Done(),
+				).Done(),
+			).Done(),
+		).Done()
+
+		Convey("When I run parse", func() {
+
+			filter, err := parser.Parse()
+
+			Convey("Then there should be no error and the filter should as expected", func() {
+				So(err, ShouldEqual, nil)
+				So(filter, ShouldNotEqual, nil)
+				So(filter.String(), ShouldEqual, expectedFilter.String())
+			})
+		})
+
+		Convey("When I run multiple parse", func() {
+
+			filter, err := parser.Parse()
+
+			So(err, ShouldEqual, nil)
+
+			p := NewFilterParser(filter.String())
+			f, err := p.Parse()
+
+			Convey("Then there should be no error and the filter should be equal to the previous filter", func() {
+				So(err, ShouldEqual, nil)
+				So(f, ShouldNotEqual, nil)
+				So(f.String(), ShouldEqual, filter.String())
+			})
+		})
+
+	})
+
+}
+
+func Test_isLetter(t *testing.T) {
+	Convey("Given I have a FilterParser", t, func() {
+		So(isLetter('<'), ShouldEqual, true)
+		So(isLetter('b'), ShouldEqual, true)
+		So(isLetter(4), ShouldEqual, false)
+		So(isLetter('\\'), ShouldEqual, true)
+	})
+}

--- a/filters.go
+++ b/filters.go
@@ -1,0 +1,462 @@
+// Copyright 2019 Aporeto Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elemental
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// An FilterComparator is the type of a operator used by a filter.
+type FilterComparator int
+
+// FilterComparators are a list of FilterOperator.
+type FilterComparators []FilterComparator
+
+// Comparators represent various comparison operations.
+const (
+	EqualComparator FilterComparator = iota
+	NotEqualComparator
+	GreaterComparator
+	GreaterOrEqualComparator
+	LesserComparator
+	LesserOrEqualComparator
+	InComparator
+	NotInComparator
+	ContainComparator
+	NotContainComparator
+	MatchComparator
+	NotMatchComparator
+	ExistsComparator
+	NotExistsComparator
+	emptyComparator
+)
+
+func (f FilterComparators) add(comparators ...FilterComparator) FilterComparators {
+
+	for _, o := range comparators {
+		f = append(f, o)
+	}
+
+	return f
+}
+
+// An FilterOperator is the type of a operator used by a filter.
+type FilterOperator int
+
+// FilterOperators are a list of FilterOperator.
+type FilterOperators []FilterOperator
+
+// Operators represent various operators.
+const (
+	AndOperator FilterOperator = iota
+	OrFilterOperator
+	AndFilterOperator
+)
+
+// FilterKeys represents a list of FilterKey.
+type FilterKeys []string
+
+// FilterValue represents a filter value.
+type FilterValue []interface{}
+
+// FilterValues represents a list of FilterValue.
+type FilterValues [][]interface{}
+
+// Then adds a new value to the receiver and returns it.
+func (f FilterValues) add(values ...interface{}) FilterValues {
+
+	fv := FilterValue{}
+	for _, v := range values {
+		fv = append(fv, v)
+	}
+
+	return append(f, fv)
+}
+
+// SubFilter is the type of subfilter
+type SubFilter []*Filter
+
+// SubFilters is is a list SubFilter,
+type SubFilters []SubFilter
+
+// FilterValueComposer adds values and operators.
+type FilterValueComposer interface {
+	Equals(interface{}) FilterKeyComposer
+	NotEquals(interface{}) FilterKeyComposer
+	GreaterOrEqualThan(interface{}) FilterKeyComposer
+	GreaterThan(interface{}) FilterKeyComposer
+	LesserOrEqualThan(interface{}) FilterKeyComposer
+	LesserThan(interface{}) FilterKeyComposer
+	In(...interface{}) FilterKeyComposer
+	NotIn(...interface{}) FilterKeyComposer
+	Contains(...interface{}) FilterKeyComposer
+	NotContains(...interface{}) FilterKeyComposer
+	Matches(...interface{}) FilterKeyComposer
+	Exists() FilterKeyComposer
+	NotExists() FilterKeyComposer
+}
+
+// FilterKeyComposer composes a filter.
+type FilterKeyComposer interface {
+	WithKey(string) FilterValueComposer
+
+	And(...*Filter) FilterKeyComposer
+	Or(...*Filter) FilterKeyComposer
+
+	Done() *Filter
+}
+
+// Filter is a filter struct which can be used with Cassandra
+type Filter struct {
+	keys        FilterKeys
+	values      FilterValues
+	comparators FilterComparators
+	operators   FilterOperators
+	ands        SubFilters
+	ors         SubFilters
+}
+
+// NewFilter returns a new filter.
+func NewFilter() *Filter {
+
+	return &Filter{
+		keys:        FilterKeys{},
+		values:      FilterValues{},
+		comparators: FilterComparators{},
+		operators:   FilterOperators{},
+		ands:        SubFilters{},
+		ors:         SubFilters{},
+	}
+}
+
+// NewFilterComposer returns a FilterComposer.
+func NewFilterComposer() FilterKeyComposer {
+
+	return NewFilter()
+}
+
+// NewFilterFromString returns a new filter computed from the given string.
+func NewFilterFromString(filter string) (*Filter, error) {
+
+	f, err := NewFilterParser(filter).Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	return f.Done(), nil
+}
+
+// Keys returns the current keys.
+func (f *Filter) Keys() FilterKeys {
+	return append(FilterKeys{}, f.keys...)
+}
+
+// Values returns the current values.
+func (f *Filter) Values() FilterValues {
+	return append(FilterValues{}, f.values...)
+}
+
+// Operators returns the current operators.
+func (f *Filter) Operators() FilterOperators {
+	return append(FilterOperators{}, f.operators...)
+}
+
+// Comparators returns the current comparators.
+func (f *Filter) Comparators() FilterComparators {
+	return append(FilterComparators{}, f.comparators...)
+}
+
+// OrFilters returns the current ors sub filters.
+func (f *Filter) OrFilters() SubFilters {
+	return append(SubFilters{}, f.ors...)
+}
+
+// AndFilters returns the current and sub filters.
+func (f *Filter) AndFilters() SubFilters {
+	return append(SubFilters{}, f.ands...)
+}
+
+// Equals adds a an equality comparator to the FilterComposer.
+func (f *Filter) Equals(value interface{}) FilterKeyComposer {
+	f.values = f.values.add(value)
+	f.comparators = f.comparators.add(EqualComparator)
+	return f
+}
+
+// NotEquals adds a an non equality comparator to the FilterComposer.
+func (f *Filter) NotEquals(value interface{}) FilterKeyComposer {
+	f.values = f.values.add(value)
+	f.comparators = f.comparators.add(NotEqualComparator)
+	return f
+}
+
+// GreaterThan adds a greater than (exclusive) comparator to the FilterComposer.
+func (f *Filter) GreaterThan(value interface{}) FilterKeyComposer {
+	f.values = f.values.add(value)
+	f.comparators = f.comparators.add(GreaterComparator)
+	return f
+}
+
+// GreaterOrEqualThan adds a greater than (inclusive) comparator to the FilterComposer.
+func (f *Filter) GreaterOrEqualThan(value interface{}) FilterKeyComposer {
+	f.values = f.values.add(value)
+	f.comparators = f.comparators.add(GreaterOrEqualComparator)
+	return f
+}
+
+// LesserThan adds a lesser than (exclusive) comparator to the FilterComposer.
+func (f *Filter) LesserThan(value interface{}) FilterKeyComposer {
+	f.values = f.values.add(value)
+	f.comparators = f.comparators.add(LesserComparator)
+	return f
+}
+
+// LesserOrEqualThan adds a lesser than (inclusive) comparator to the FilterComposer.
+func (f *Filter) LesserOrEqualThan(value interface{}) FilterKeyComposer {
+	f.values = f.values.add(value)
+	f.comparators = f.comparators.add(LesserOrEqualComparator)
+	return f
+}
+
+// In adds a in comparator to the FilterComposer.
+func (f *Filter) In(values ...interface{}) FilterKeyComposer {
+	f.values = f.values.add(values...)
+	f.comparators = f.comparators.add(InComparator)
+	return f
+}
+
+// NotIn adds a not in comparator to the FilterComposer.
+func (f *Filter) NotIn(values ...interface{}) FilterKeyComposer {
+	f.values = f.values.add(values...)
+	f.comparators = f.comparators.add(NotInComparator)
+	return f
+}
+
+// Contains adds a contains comparator to the FilterComposer.
+func (f *Filter) Contains(values ...interface{}) FilterKeyComposer {
+	f.values = f.values.add(values...)
+	f.comparators = f.comparators.add(ContainComparator)
+	return f
+}
+
+// NotContains adds a contains comparator to the FilterComposer.
+func (f *Filter) NotContains(values ...interface{}) FilterKeyComposer {
+	f.values = f.values.add(values...)
+	f.comparators = f.comparators.add(NotContainComparator)
+	return f
+}
+
+// Matches adds a match comparator to the FilterComposer.
+func (f *Filter) Matches(values ...interface{}) FilterKeyComposer {
+	f.values = f.values.add(values...)
+	f.comparators = f.comparators.add(MatchComparator)
+	return f
+}
+
+// Exists adds an exists comparator to the FilterComposer.
+func (f *Filter) Exists() FilterKeyComposer {
+	f.values = f.values.add(true)
+	f.comparators = f.comparators.add(ExistsComparator)
+	return f
+}
+
+// NotExists adds an not exist comparator to the FilterComposer.
+func (f *Filter) NotExists() FilterKeyComposer {
+	f.values = f.values.add(false)
+	f.comparators = f.comparators.add(NotExistsComparator)
+	return f
+}
+
+// WithKey adds a key to FilterComposer.
+func (f *Filter) WithKey(key string) FilterValueComposer {
+	f.operators = append(f.operators, AndOperator)
+	f.keys = append(f.keys, key)
+	f.ands = append(f.ands, nil)
+	f.ors = append(f.ors, nil)
+	return f
+}
+
+// And adds a new sub filter to FilterComposer.
+func (f *Filter) And(filters ...*Filter) FilterKeyComposer {
+	f.operators = append(f.operators, AndFilterOperator)
+	f.comparators = append(f.comparators, emptyComparator)
+	f.keys = append(f.keys, "")
+	f.values = append(f.values, nil)
+	f.ands = append(f.ands, filters)
+	f.ors = append(f.ors, nil)
+	return f
+}
+
+// Or adds a new sub filter to FilterComposer.
+func (f *Filter) Or(filters ...*Filter) FilterKeyComposer {
+	f.operators = append(f.operators, OrFilterOperator)
+	f.comparators = append(f.comparators, emptyComparator)
+	f.keys = append(f.keys, "")
+	f.values = append(f.values, nil)
+	f.ands = append(f.ands, nil)
+	f.ors = append(f.ors, filters)
+	return f
+}
+
+// Done terminates the filter composition and returns the *Filter.
+func (f *Filter) Done() *Filter {
+	return f
+}
+
+func (f *Filter) String() string {
+
+	var buffer bytes.Buffer
+
+	for i, operator := range f.operators {
+		if i > 0 {
+			writeString(&buffer, translateOperator(operator))
+			writeString(&buffer, " ")
+		}
+
+		switch operator {
+
+		case AndOperator:
+			writeString(&buffer, f.keys[i])
+			writeString(&buffer, " ")
+			writeString(&buffer, translateComparator(f.comparators[i]))
+			if f.comparators[i] != ExistsComparator && f.comparators[i] != NotExistsComparator {
+				writeString(&buffer, " ")
+				writeString(&buffer, translateValue(f.comparators[i], f.values[i]))
+			}
+
+		case AndFilterOperator:
+			var strs []string
+			for _, andf := range f.ands[i] {
+				strs = append(strs, fmt.Sprintf("(%s)", andf))
+			}
+			writeString(&buffer, fmt.Sprintf("(%s)", strings.Join(strs, " and ")))
+
+		case OrFilterOperator:
+			var strs []string
+			for _, orf := range f.ors[i] {
+				strs = append(strs, fmt.Sprintf("(%s)", orf))
+			}
+			writeString(&buffer, fmt.Sprintf("(%s)", strings.Join(strs, " or ")))
+		}
+
+		if i+1 < len(f.operators) {
+			writeString(&buffer, " ")
+		}
+	}
+
+	return buffer.String()
+}
+
+func translateComparator(comparator FilterComparator) string {
+
+	switch comparator {
+	case EqualComparator:
+		return "=="
+	case NotEqualComparator:
+		return "!="
+	case GreaterOrEqualComparator:
+		return ">="
+	case GreaterComparator:
+		return ">"
+	case LesserOrEqualComparator:
+		return "<="
+	case LesserComparator:
+		return "<"
+	case InComparator:
+		return "in"
+	case NotInComparator:
+		return "not in"
+	case ContainComparator:
+		return "contains"
+	case NotContainComparator:
+		return "not contains"
+	case MatchComparator:
+		return "matches"
+	case ExistsComparator:
+		return "exists"
+	case NotExistsComparator:
+		return "not exists"
+	default:
+		panic(fmt.Sprintf("Unknown comparator: %d", comparator))
+	}
+}
+
+func translateOperator(operator FilterOperator) string {
+
+	switch operator {
+	case AndOperator, AndFilterOperator:
+		return "and"
+	case OrFilterOperator:
+		return "or"
+	default:
+		panic(fmt.Sprintf("Unknown operator: %d", operator))
+	}
+}
+
+func translateValue(comparator FilterComparator, value interface{}) string {
+
+	v := reflect.ValueOf(value)
+	if comparator != ContainComparator && comparator != InComparator && comparator != MatchComparator {
+		if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+			v = reflect.ValueOf(v.Index(0).Interface())
+		}
+	}
+
+	switch v.Kind() {
+
+	case reflect.String:
+		return fmt.Sprintf(`"%s"`, v.Interface())
+
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Int8, reflect.Uint, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64, reflect.Uint8:
+		if v.Type().Name() == "Duration" {
+			if v.Interface() == time.Duration(0) {
+				return `now()`
+			}
+			return fmt.Sprintf(`now("%s")`, v.Interface())
+		}
+
+		return fmt.Sprintf(`%d`, v.Interface())
+
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf(`%f`, v.Interface())
+
+	case reflect.Bool:
+		return fmt.Sprintf(`%t`, v.Interface())
+
+	case reflect.Slice, reflect.Array:
+		var final []string
+		for i := 0; i < v.Len(); i++ {
+
+			final = append(final, translateValue(comparator, v.Index(i).Interface()))
+		}
+		return fmt.Sprintf(`[%s]`, strings.Join(final, ", "))
+
+	default:
+		if v.Type().Name() == "Time" {
+			return fmt.Sprintf(`date("%s")`, v.Interface().(time.Time).Format(time.RFC3339))
+		}
+		return fmt.Sprintf(`%v`, v.Interface())
+	}
+}
+
+func writeString(buffer *bytes.Buffer, str string) {
+
+	if _, err := buffer.WriteString(str); err != nil {
+		panic(err)
+	}
+}

--- a/filterscanner.go
+++ b/filterscanner.go
@@ -1,0 +1,183 @@
+// Copyright 2019 Aporeto Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elemental
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// scanner scans a given input
+type scanner struct {
+	buf          bytes.Buffer
+	isWhitespace checkRuneFunc
+	isLetter     checkRuneFunc
+	isDigit      checkRuneFunc
+}
+
+// newScanner returns an instance of a Scanner.
+func newScanner(
+	input string,
+) *scanner {
+	var buf bytes.Buffer
+	buf.WriteString(input)
+
+	return &scanner{
+		buf:          buf,
+		isWhitespace: isWhitespace,
+		isLetter:     isLetter,
+		isDigit:      isDigit,
+	}
+}
+
+// read returns the next rune or eof
+func (s *scanner) read() rune {
+
+	ch, _, err := s.buf.ReadRune()
+	if err != nil {
+		return runeEOF
+	}
+	return ch
+}
+
+// peekNextRune returns the next rune but does not read it.
+func (s *scanner) peekNextRune() rune {
+
+	if s.buf.Len() == 0 {
+		return runeEOF
+	}
+
+	ch, _ := utf8.DecodeRune(s.buf.Bytes()[0:])
+	return ch
+}
+
+// unread a previously read rune
+func (s *scanner) unread() {
+	_ = s.buf.UnreadRune()
+}
+
+// scan returns the next token and literal value.
+func (s *scanner) scan() (parserToken, string) {
+
+	ch := s.read()
+
+	if s.isWhitespace(ch) {
+		s.unread()
+		return s.scanWhitespace()
+	}
+
+	if isOperatorStart(ch) {
+		// Chack if the next run can create an operator
+		nextCh := s.peekNextRune()
+		if nextCh != runeEOF {
+			if token, literal, ok := isOperator(ch, nextCh); ok {
+				s.read() // read only if it has matched.
+				return token, literal
+			}
+		}
+
+		// Check if the current rune is an operator
+		if token, literal, ok := isOperator(ch); ok {
+			return token, literal
+		}
+	}
+
+	if s.isLetter(ch) || s.isDigit(ch) {
+		s.unread()
+		return s.scanWord()
+	}
+
+	token, ok := runeToToken[ch]
+	if !ok {
+		return parserTokenILLEGAL, string(ch)
+	}
+
+	return token, string(ch)
+}
+
+// scanWhitespace consumes the current rune and all contiguous whitespace.
+func (s *scanner) scanWhitespace() (parserToken, string) {
+
+	var buf bytes.Buffer
+	buf.WriteRune(s.read())
+
+	for {
+		if ch := s.read(); ch == runeEOF {
+			break
+		} else if !s.isWhitespace(ch) {
+			s.unread()
+			break
+		} else {
+			buf.WriteRune(ch)
+		}
+	}
+
+	return parserTokenWHITESPACE, buf.String()
+}
+
+// scanWord consumes the current rune and all contiguous letters / digits.
+func (s *scanner) scanWord() (parserToken, string) {
+
+	var buf bytes.Buffer
+	buf.WriteRune(s.read())
+
+	for {
+		if ch := s.read(); ch == runeEOF {
+			break
+		} else if !s.isLetter(ch) && !s.isDigit(ch) {
+			s.unread()
+			break
+		} else {
+			if ch == '\\' {
+				// Move forward
+				ch = s.read()
+			}
+
+			if isOperatorStart(ch) {
+				// Check if the next rune can create an operator
+				nextCh := s.peekNextRune()
+				if nextCh != runeEOF {
+					if _, _, ok := isOperator(ch, nextCh); ok {
+						s.unread() // unread ch rune
+						break
+					}
+				}
+
+				// Check if ch is an operator by itself
+				if _, _, ok := isOperator(ch); ok {
+					s.unread()
+					break
+				}
+			}
+
+			buf.WriteRune(ch)
+		}
+	}
+
+	return stringToToken(buf.String())
+}
+
+func stringToToken(output string) (parserToken, string) {
+
+	upper := strings.ToUpper(output)
+
+	if token, ok := wordToToken[upper]; ok {
+		return token, output
+	}
+
+	if token, ok := operatorsToToken[upper]; ok {
+		return token, output
+	}
+
+	return parserTokenWORD, output
+}


### PR DESCRIPTION
This patch moves the `manipulate.Filter` to elemental.

This patch is required to allow a deeper understanding of filters, so libraries that are not necessarily using manipulate can use filtering.

The end goal of this move is to allow 
- checking is an `elemental.Identifiable` matches a filter
- extracting matching `elemental.Identifiable` from a `elemental.Identifiables` list
- advanced push filtering