### PR TITLE
encode: fix nil check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmd/elegen/build
 *.cov
 artifacts
 profile.out
+.idea/*

--- a/encoding.go
+++ b/encoding.go
@@ -130,7 +130,7 @@ func Decode(encoding EncodingType, data []byte, dest interface{}) error {
 // from the given acceptType.
 func Encode(encoding EncodingType, obj interface{}) ([]byte, error) {
 
-	if obj == nil {
+	if obj == nil || reflect.ValueOf(obj).IsNil() {
 		return nil, fmt.Errorf("encode received a nil object")
 	}
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -99,6 +99,23 @@ func TestEncodeDecode(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 		})
+
+		Convey(fmt.Sprintf("Encode will throw an error if passed in a nil interface or an interface holding a nil value using encoding %s", encoding), t, func() {
+
+			var nilPointer *int
+			cases := map[string]interface{}{
+				"nil interface": nil,
+				"nil pointer":   nilPointer,
+			}
+
+			for description, object := range cases {
+				Convey(fmt.Sprintf("passing in a %s should result in an error", description), func() {
+					data, err := Encode(encoding, object)
+					So(data, ShouldBeNil)
+					So(err, ShouldNotBeNil)
+				})
+			}
+		})
 	}
 
 	test(EncodingTypeJSON)


### PR DESCRIPTION
https://github.com/aporeto-inc/elemental/blob/master/encoding.go#L144

An interface will only be `nil`, *if and only if*, both it's type and value are nil. If the caller of `Encode` passes in a `nil` pointer here, this condition would not trigger because the interface is not actually nil anymore as it now has a type set (i.e. `*T`) even though it's value is `nil`!

https://play.golang.org/p/E1tlCOb32P

I ran into this by passing a `nil` `Publication` to cause a deliberate encoding error in my unit test, but to my surprise this did not trigger this short circuit.

Example of a caller that can pass in a `nil` pointer type - https://github.com/aporeto-inc/bahamut/blob/master/pubsub_nats.go#L69

---

If this patch is accepted, please create a new tag `v1.47.0` 🙏 