### PR TITLE
fix: addresses the bug introduced in #40 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmd/elegen/build
 *.cov
 artifacts
 profile.out
+.idea/*

--- a/encoding.go
+++ b/encoding.go
@@ -141,8 +141,9 @@ func Decode(encoding EncodingType, data []byte, dest interface{}) error {
 // from the given acceptType.
 func Encode(encoding EncodingType, obj interface{}) ([]byte, error) {
 
-	if obj == nil {
-		return nil, fmt.Errorf("encode received a nil object")
+	valObj := reflect.ValueOf(obj)
+	if obj == nil || (valObj.Kind() == reflect.Ptr && valObj.IsNil()) {
+		return nil, fmt.Errorf("encode received a nil object or one containing a nil pointer")
 	}
 
 	var enc *codec.Encoder

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -110,6 +110,23 @@ func TestEncodeDecode(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 		})
+
+		Convey(fmt.Sprintf("Encode will throw an error if passed in a nil interface or an interface holding a nil pointer using encoding %s", encoding), t, func() {
+
+			var nilPointer *int
+			cases := map[string]interface{}{
+				"nil interface": nil,
+				"nil pointer":   nilPointer,
+			}
+
+			for description, object := range cases {
+				Convey(fmt.Sprintf("passing in a %s should result in an error", description), func() {
+					data, err := Encode(encoding, object)
+					So(data, ShouldBeNil)
+					So(err, ShouldNotBeNil)
+				})
+			}
+		})
 	}
 
 	test(EncodingTypeJSON)


### PR DESCRIPTION
actually checking if the type is a pointer otherwise you could 💥 if you encounter a type that cannot be nil (e.g. a `struct`)