### PR TITLE
new: added AtomicJob

### DIFF
--- a/atomicjob.go
+++ b/atomicjob.go
@@ -1,0 +1,64 @@
+package elemental
+
+import (
+	"context"
+	"sync"
+)
+
+// AtomicJob takes a func() error and returns a func(context.Context) error.
+// The returned function can be called as many time as you like, but only
+// one instance of the given job can be run at the same time.
+//
+// The returned function will either execute job if it
+// it not already running or wait for the currently running job to finish.
+// In both cases, the returned error from the job will be forwareded and returned
+// to every caller.
+//
+// You must pass a context.Context to the returned function so you can
+// control how much time you are willing to wait for the job to complete.
+//
+// If you wish to change some external state from within the job function,
+// it is your responsability to ensure everything is thread safe.
+func AtomicJob(job func() error) func(context.Context) error {
+
+	var l sync.RWMutex
+	var errorChs []chan error
+
+	sem := make(chan struct{}, 1)
+
+	return func(ctx context.Context) error {
+
+		errCh := make(chan error)
+
+		l.Lock()
+		errorChs = append(errorChs, errCh)
+		l.Unlock()
+
+		select {
+		case sem <- struct{}{}:
+
+			go func() {
+
+				err := job()
+
+				l.Lock()
+				for _, ch := range errorChs {
+					ch <- err
+				}
+				errorChs = nil
+				l.Unlock()
+
+				<-sem
+			}()
+
+		default:
+		}
+
+		select {
+		case err := <-errCh:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/atomicjob.go
+++ b/atomicjob.go
@@ -18,7 +18,7 @@ import (
 // control how much time you are willing to wait for the job to complete.
 //
 // If you wish to change some external state from within the job function,
-// it is your responsability to ensure everything is thread safe.
+// it is your responsibility to ensure everything is thread safe.
 func AtomicJob(job func() error) func(context.Context) error {
 
 	var l sync.RWMutex

--- a/atomicjob_test.go
+++ b/atomicjob_test.go
@@ -1,0 +1,172 @@
+package elemental
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAtomicJob(t *testing.T) {
+
+	Convey("Given I call a wrapped job once and it works", t, func() {
+
+		var counter int64
+
+		f := AtomicJob(func() error {
+			time.Sleep(time.Second)
+			atomic.AddInt64(&counter, 1)
+			return nil
+		})
+
+		err := f(context.Background())
+
+		Convey("Then err should be nil", func() {
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Then the job should have been executed", func() {
+			So(atomic.LoadInt64(&counter), ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given I call a wrapped job once and it fails", t, func() {
+
+		var counter int64
+
+		f := AtomicJob(func() error {
+			time.Sleep(time.Second)
+			atomic.AddInt64(&counter, 1)
+			return fmt.Errorf("oh noes")
+		})
+
+		err := f(context.Background())
+
+		Convey("Then err should be nil", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "oh noes")
+		})
+
+		Convey("Then the job should have been executed", func() {
+			So(atomic.LoadInt64(&counter), ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given I call a wrapped job but context is canceled", t, func() {
+
+		var counter int64
+
+		f := AtomicJob(func() error {
+			time.Sleep(time.Second)
+			atomic.AddInt64(&counter, 1)
+			return nil
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := f(ctx)
+
+		Convey("Then err should not be nil", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "context canceled")
+		})
+
+		Convey("Then the job should have been executed", func() {
+			So(atomic.LoadInt64(&counter), ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given I call a wrapped job twice and it fails", t, func() {
+
+		var counter int64
+
+		f := AtomicJob(func() error {
+			time.Sleep(time.Second)
+			atomic.AddInt64(&counter, 1)
+			return fmt.Errorf("boom")
+		})
+
+		var err1 atomic.Value
+
+		ready := make(chan struct{})
+		go func() {
+			ready <- struct{}{}
+			err1.Store(f(context.Background()))
+		}()
+
+		// wait for the first trigger to be running
+		select {
+		case <-ready:
+		case <-time.After(1 * time.Second):
+			panic("job did not trigger in time")
+		}
+
+		// invoke a second marker trigger
+		err2 := f(context.Background())
+
+		time.Sleep(300 * time.Millisecond)
+
+		Convey("Then err1 and err2 should not be nil", func() {
+			e := err1.Load().(error)
+			So(e, ShouldNotBeNil)
+			So(e.Error(), ShouldEqual, "boom")
+
+			So(err2, ShouldNotBeNil)
+			So(err2.Error(), ShouldEqual, "boom")
+		})
+
+		Convey("Then the job should have been executed", func() {
+			So(atomic.LoadInt64(&counter), ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given I call a wrapped job a lot in parallel", t, func() {
+
+		var counter int64
+		f := AtomicJob(func() error {
+			time.Sleep(time.Second)
+			atomic.AddInt64(&counter, 1)
+			return nil
+		})
+
+		var err1 atomic.Value
+
+		ready := make(chan struct{})
+		go func() {
+			ready <- struct{}{}
+			if e := f(context.Background()); e != nil {
+				err1.Store(e)
+			}
+		}()
+
+		// wait for the first trigger to be running
+		select {
+		case <-ready:
+		case <-time.After(1 * time.Second):
+			panic("job did not trigger in time")
+		}
+
+		// invoke 100 other random trigger
+		for i := 0; i < 100; i++ {
+			go f(context.Background()) // nolint
+		}
+
+		// invoke a second marker trigger
+		err2 := f(context.Background())
+
+		time.Sleep(300 * time.Millisecond)
+
+		Convey("Then err1 and err2 should be nil", func() {
+			So(err1.Load(), ShouldBeNil)
+			So(err2, ShouldBeNil)
+		})
+
+		Convey("Then the job should have been executed", func() {
+			So(atomic.LoadInt64(&counter), ShouldEqual, 1)
+		})
+	})
+}


### PR DESCRIPTION

This patch adds the function AtomicJob that
allows to make a function execution atomic
while still returning any eventual error to every callers.