### PR TITLE
Add support for fine-grained identity filtering on websockets

### DIFF
--- a/push_config.go
+++ b/push_config.go
@@ -159,6 +159,11 @@ func (pc *PushConfig) IsFilteredOut(identityName string, eventType EventType) bo
 // FilterForIdentity returns the associated fine-grained filter for the given identity. In the event that no fine-grained
 // filter has been configured for the identity, the second return value (a boolean), will be set to false.
 func (pc *PushConfig) FilterForIdentity(identityName string) (*Filter, bool) {
+
+	if pc.parsedIdentityFilters == nil {
+		return nil, false
+	}
+
 	filter, found := pc.parsedIdentityFilters[identityName]
 	return filter, found
 }

--- a/push_config_test.go
+++ b/push_config_test.go
@@ -33,6 +33,22 @@ func TestPushConfig_NewPushConfig(t *testing.T) {
 	})
 }
 
+// just keeping this for backwards compatibility so we don't break the API by accident by removing the old constructor API
+func TestPushConfig_NewPushFilter(t *testing.T) {
+
+	Convey("Given I create a new NewPushFilter", t, func() {
+
+		f := NewPushFilter()
+
+		Convey("Then it should be correctly initialized", func() {
+			So(f.Identities, ShouldNotBeNil)
+			So(f.IdentityFilters, ShouldNotBeNil)
+			So(f.parsedIdentityFilters, ShouldNotBeNil)
+			So(f.Params, ShouldBeNil)
+		})
+	})
+}
+
 func TestPushConfig_Duplicate(t *testing.T) {
 
 	Convey("Given I create a new PushConfig", t, func() {

--- a/push_filter.go
+++ b/push_filter.go
@@ -16,22 +16,40 @@ import (
 	"net/url"
 )
 
-// A PushFilter represents an abstract filter for filtering out push notifications.
-type PushFilter struct {
-	Identities map[string][]EventType `msgpack:"identities" json:"identities"`
-	Params     url.Values             `msgpack:"parameters" json:"parameters"`
+// A PushFilter represents an abstract filter for filtering out push notifications. This is now aliased to PushConfig as a
+// result of re-naming the type.
+//
+// Deprecated: use the new name PushConfig instead
+type PushFilter = PushConfig
+
+// NewPushFilter returns a new PushFilter. NewPushFilter is now aliased to NewPushConfig. This was done for backwards
+// compatibility as a result of the re-naming of PushFilter to PushConfig.
+//
+// Deprecated: use the new name NewPushConfig instead
+var NewPushFilter = NewPushConfig
+
+// A PushConfig represents an abstract filter for filtering out push notifications.
+//
+// The 'IdentityFilters' field is a mapping between a filtered identity and the string representation of an elemental.Filter.
+// A client will supply this attribute if they want fine-grained filtering on the set of identities that they are filtering on.
+// If this attribute has been supplied, the identities passed to 'IdentityFilters' must be a subset of the identities passed to
+// 'Identities'; passing in identities that are not provided in the 'Identities' field will be ignored.
+type PushConfig struct {
+	Identities      map[string][]EventType `msgpack:"identities" json:"identities"`
+	IdentityFilters map[string]string      `msgpack:"filters"    json:"filters"`
+	Params          url.Values             `msgpack:"parameters" json:"parameters"`
 }
 
-// NewPushFilter returns a new PushFilter.
-func NewPushFilter() *PushFilter {
+// NewPushConfig returns a new PushConfig.
+func NewPushConfig() *PushConfig {
 
-	return &PushFilter{
+	return &PushConfig{
 		Identities: map[string][]EventType{},
 	}
 }
 
 // SetParameter sets the values of the parameter with the given key.
-func (f *PushFilter) SetParameter(key string, values ...string) {
+func (f *PushConfig) SetParameter(key string, values ...string) {
 
 	if f.Params == nil {
 		f.Params = url.Values{}
@@ -41,7 +59,7 @@ func (f *PushFilter) SetParameter(key string, values ...string) {
 }
 
 // Parameters returns a copy of all the parameters.
-func (f *PushFilter) Parameters() url.Values {
+func (f *PushConfig) Parameters() url.Values {
 
 	if f.Params == nil {
 		return nil
@@ -55,14 +73,14 @@ func (f *PushFilter) Parameters() url.Values {
 	return out
 }
 
-// FilterIdentity adds the given identity for the given eventTypes in the PushFilter.
-func (f *PushFilter) FilterIdentity(identityName string, eventTypes ...EventType) {
+// FilterIdentity adds the given identity for the given eventTypes in the PushConfig.
+func (f *PushConfig) FilterIdentity(identityName string, eventTypes ...EventType) {
 
 	f.Identities[identityName] = eventTypes
 }
 
-// IsFilteredOut returns true if the given Identity is not part of the PushFilter.
-func (f *PushFilter) IsFilteredOut(identityName string, eventType EventType) bool {
+// IsFilteredOut returns true if the given Identity is not part of the PushConfig.
+func (f *PushConfig) IsFilteredOut(identityName string, eventType EventType) bool {
 
 	// if the identities list is empty, we filter nothing.
 	if len(f.Identities) == 0 {
@@ -91,10 +109,10 @@ func (f *PushFilter) IsFilteredOut(identityName string, eventType EventType) boo
 	return true
 }
 
-// Duplicate duplicates the PushFilter.
-func (f *PushFilter) Duplicate() *PushFilter {
+// Duplicate duplicates the PushConfig.
+func (f *PushConfig) Duplicate() *PushConfig {
 
-	nf := NewPushFilter()
+	nf := NewPushConfig()
 
 	for id, types := range f.Identities {
 		nf.FilterIdentity(id, types...)
@@ -107,7 +125,7 @@ func (f *PushFilter) Duplicate() *PushFilter {
 	return nf
 }
 
-func (f *PushFilter) String() string {
+func (f *PushConfig) String() string {
 
 	return fmt.Sprintf("<pushfilter identities:%s>", f.Identities)
 }

--- a/push_filter_test.go
+++ b/push_filter_test.go
@@ -18,11 +18,11 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestPushFilter_NewPushFilter(t *testing.T) {
+func TestPushFilter_NewPushConfig(t *testing.T) {
 
 	Convey("Given I create a new PushFilter", t, func() {
 
-		f := NewPushFilter()
+		f := NewPushConfig()
 
 		Convey("Then it should be correctly initialized", func() {
 			So(f.Identities, ShouldNotBeNil)
@@ -35,7 +35,7 @@ func TestPushFilter_Duplicate(t *testing.T) {
 
 	Convey("Given I create a new PushFilter", t, func() {
 
-		f := NewPushFilter()
+		f := NewPushConfig()
 
 		f.SetParameter("key", "values")
 
@@ -61,7 +61,7 @@ func TestPushFilter_Parameters(t *testing.T) {
 
 	Convey("Given I create a new PushFilter", t, func() {
 
-		f := NewPushFilter()
+		f := NewPushConfig()
 
 		Convey("When I call SetParameter", func() {
 
@@ -82,7 +82,7 @@ func TestPushFilter_Parameters(t *testing.T) {
 
 	Convey("Given I have a push filter with no parameters", t, func() {
 
-		f := NewPushFilter()
+		f := NewPushConfig()
 
 		Convey("When I call Parameters", func() {
 
@@ -99,7 +99,7 @@ func TestPushFilter_IsFilteredOut(t *testing.T) {
 
 	Convey("Given I create a new PushFilter", t, func() {
 
-		f := NewPushFilter()
+		f := NewPushConfig()
 
 		Convey("When I check if i1 is filtered with a nil value for identities", func() {
 
@@ -192,7 +192,7 @@ func TestPushFilter_String(t *testing.T) {
 
 	Convey("Given I create a new PushFilter", t, func() {
 
-		f := NewPushFilter()
+		f := NewPushConfig()
 
 		f.FilterIdentity("i1", EventCreate, EventDelete)
 


### PR DESCRIPTION
### Issue: https://github.com/aporeto-inc/aporeto/issues/1699

TODOs

- [x] Add new attribute `IdentityFilters` to `PushFilter`
- [x] Remove all references to `PushFilter`
- [x] Rename `PushFilter` to `PushConfig` for better naming
- [x] Add new attribute that is the parsed identity filters so that the configured filters for a given socket session do not need to be parsed on each push event that is received
    - This needs a new API
    - This needs a new set of unit tests
- [x] The String method needs to be updated to print the current set of identity filters as well