### PR TITLE
Add custom error type for errors returned by the 'MatchesFilter' API 

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -63,7 +63,10 @@ func MatchesFilter(identifiable AttributeSpecifiable, filter *Filter, opts ...Ma
 				NotInComparator,
 				ContainComparator,
 				NotContainComparator:
-				return false, fmt.Errorf("elemental: unsuported comparator %q", translateComparator(filter.Comparators()[i]))
+				return false, &MatcherError{
+					kind:        KindUnsupportedComparator,
+					description: fmt.Sprintf("unsuported comparator %q", translateComparator(filter.Comparators()[i])),
+				}
 			default:
 				panic(fmt.Errorf("elemental: unknown comparator %q", translateComparator(filter.Comparators()[i])))
 			}

--- a/matcher.go
+++ b/matcher.go
@@ -64,8 +64,7 @@ func MatchesFilter(identifiable AttributeSpecifiable, filter *Filter, opts ...Ma
 				ContainComparator,
 				NotContainComparator:
 				return false, &MatcherError{
-					err:   ErrUnsupportedComparator,
-					debug: fmt.Sprintf("comparator: %q", translateComparator(filter.Comparators()[i])),
+					err: ErrUnsupportedComparator{err: fmt.Errorf("unsupported comparator %q", translateComparator(filter.Comparators()[i]))},
 				}
 			default:
 				panic(fmt.Errorf("elemental: unknown comparator %q", translateComparator(filter.Comparators()[i])))

--- a/matcher.go
+++ b/matcher.go
@@ -64,7 +64,7 @@ func MatchesFilter(identifiable AttributeSpecifiable, filter *Filter, opts ...Ma
 				ContainComparator,
 				NotContainComparator:
 				return false, &MatcherError{
-					Err: ErrUnsupportedComparator{Err: fmt.Errorf("unsupported comparator %q", translateComparator(filter.Comparators()[i]))},
+					Err: ErrUnsupportedComparator{Err: fmt.Errorf("%q", translateComparator(filter.Comparators()[i]))},
 				}
 			default:
 				panic(fmt.Errorf("elemental: unknown comparator %q", translateComparator(filter.Comparators()[i])))

--- a/matcher.go
+++ b/matcher.go
@@ -64,7 +64,7 @@ func MatchesFilter(identifiable AttributeSpecifiable, filter *Filter, opts ...Ma
 				ContainComparator,
 				NotContainComparator:
 				return false, &MatcherError{
-					err: ErrUnsupportedComparator{err: fmt.Errorf("unsupported comparator %q", translateComparator(filter.Comparators()[i]))},
+					Err: ErrUnsupportedComparator{Err: fmt.Errorf("unsupported comparator %q", translateComparator(filter.Comparators()[i]))},
 				}
 			default:
 				panic(fmt.Errorf("elemental: unknown comparator %q", translateComparator(filter.Comparators()[i])))

--- a/matcher.go
+++ b/matcher.go
@@ -64,8 +64,8 @@ func MatchesFilter(identifiable AttributeSpecifiable, filter *Filter, opts ...Ma
 				ContainComparator,
 				NotContainComparator:
 				return false, &MatcherError{
-					kind:        KindUnsupportedComparator,
-					description: fmt.Sprintf("unsuported comparator %q", translateComparator(filter.Comparators()[i])),
+					err:   ErrUnsupportedComparator,
+					debug: fmt.Sprintf("comparator: %q", translateComparator(filter.Comparators()[i])),
 				}
 			default:
 				panic(fmt.Errorf("elemental: unknown comparator %q", translateComparator(filter.Comparators()[i])))

--- a/matcher_errors.go
+++ b/matcher_errors.go
@@ -1,0 +1,36 @@
+package elemental
+
+import "fmt"
+
+const (
+	// KindUnsupportedComparator represents a MatcherError kind for when an unsupported comparator has been used
+	KindUnsupportedComparator MatcherErrorKind = iota + 1
+)
+
+// MatcherErrorKind represents the kind of matcher error that has occurred, client's can use this in their error handling
+// to deal with specific error cases
+type MatcherErrorKind int
+
+func (k MatcherErrorKind) String() string {
+	switch k {
+	case KindUnsupportedComparator:
+		return "KindUnsupportedComparator"
+	default:
+		return "UnknownMatcherErrorKind"
+	}
+}
+
+// MatcherError is the error type that will be returned by elemental.MatchesFilter in the event that it returns an error
+type MatcherError struct {
+	kind        MatcherErrorKind
+	description string
+}
+
+func (me *MatcherError) Error() string {
+	return fmt.Sprintf("elemental: %s - kind: %s", me.description, me.kind)
+}
+
+// Kind returns the MatcherErrorKind for the matcher error
+func (me *MatcherError) Kind() MatcherErrorKind {
+	return me.kind
+}

--- a/matcher_errors.go
+++ b/matcher_errors.go
@@ -1,36 +1,36 @@
 package elemental
 
-import "fmt"
-
-const (
-	// KindUnsupportedComparator represents a MatcherError kind for when an unsupported comparator has been used
-	KindUnsupportedComparator MatcherErrorKind = iota + 1
+import (
+	"errors"
+	"strings"
 )
 
-// MatcherErrorKind represents the kind of matcher error that has occurred, client's can use this in their error handling
-// to deal with specific error cases
-type MatcherErrorKind int
-
-func (k MatcherErrorKind) String() string {
-	switch k {
-	case KindUnsupportedComparator:
-		return "KindUnsupportedComparator"
-	default:
-		return "UnknownMatcherErrorKind"
-	}
-}
+var (
+	// ErrUnsupportedComparator is the error type that will be returned in the event that that an unsupported comparator
+	// is used in the filter.
+	ErrUnsupportedComparator = errors.New("filter is using an unsupported comparator")
+)
 
 // MatcherError is the error type that will be returned by elemental.MatchesFilter in the event that it returns an error
 type MatcherError struct {
-	kind        MatcherErrorKind
-	description string
+	err   error
+	debug string
 }
 
 func (me *MatcherError) Error() string {
-	return fmt.Sprintf("elemental: %s - kind: %s", me.description, me.kind)
+	var description strings.Builder
+	description.WriteString("elemental: " + me.err.Error())
+
+	// add debug copy if it is present
+	if me.debug != "" {
+		description.WriteString(" - " + me.debug)
+	}
+
+	return description.String()
 }
 
-// Kind returns the MatcherErrorKind for the matcher error
-func (me *MatcherError) Kind() MatcherErrorKind {
-	return me.kind
+// Unwrap returns the the error contained in 'MatcherError'. This is a special method that aids in error handling for clients
+// using Go 1.13 and beyond as they can now utilize the new 'Is' function added to the 'errors' package.
+func (me *MatcherError) Unwrap() error {
+	return me.err
 }

--- a/matcher_errors.go
+++ b/matcher_errors.go
@@ -23,7 +23,7 @@ func (e ErrUnsupportedComparator) Unwrap() error {
 }
 
 func (e ErrUnsupportedComparator) Error() string {
-	return e.Err.Error()
+	return fmt.Sprintf("unsupported comparator: %s", e.Err)
 }
 
 // MatcherError is the error type that will be returned by elemental.MatchesFilter in the event that it returns an error

--- a/matcher_errors.go
+++ b/matcher_errors.go
@@ -32,7 +32,7 @@ type MatcherError struct {
 }
 
 func (me *MatcherError) Error() string {
-	return fmt.Sprintf("elemental: %s", me.Err)
+	return fmt.Sprintf("elemental: unable to match: %s", me.Err)
 }
 
 // Unwrap returns the the error contained in 'MatcherError'. This is a special method that aids in error handling for clients

--- a/matcher_errors.go
+++ b/matcher_errors.go
@@ -8,7 +8,7 @@ import (
 // ErrUnsupportedComparator is the error type that will be returned in the event that that an unsupported comparator
 // is used in the filter.
 type ErrUnsupportedComparator struct {
-	err error
+	Err error
 }
 
 // Is reports whether the provided error has the same type as ErrUnsupportedComparator. This was added as part of the new
@@ -19,24 +19,24 @@ func (e ErrUnsupportedComparator) Is(err error) bool {
 
 // Unwrap returns the embedded error in ErrUnsupportedComparator.
 func (e ErrUnsupportedComparator) Unwrap() error {
-	return e.err
+	return e.Err
 }
 
 func (e ErrUnsupportedComparator) Error() string {
-	return e.err.Error()
+	return e.Err.Error()
 }
 
 // MatcherError is the error type that will be returned by elemental.MatchesFilter in the event that it returns an error
 type MatcherError struct {
-	err error
+	Err error
 }
 
 func (me *MatcherError) Error() string {
-	return fmt.Sprintf("elemental: %s", me.err)
+	return fmt.Sprintf("elemental: %s", me.Err)
 }
 
 // Unwrap returns the the error contained in 'MatcherError'. This is a special method that aids in error handling for clients
 // using Go 1.13 and beyond as they can now utilize the new 'Is' function added to the 'errors' package.
 func (me *MatcherError) Unwrap() error {
-	return me.err
+	return me.Err
 }

--- a/matcher_errors.go
+++ b/matcher_errors.go
@@ -1,32 +1,38 @@
 package elemental
 
 import (
-	"errors"
-	"strings"
+	"fmt"
+	"reflect"
 )
 
-var (
-	// ErrUnsupportedComparator is the error type that will be returned in the event that that an unsupported comparator
-	// is used in the filter.
-	ErrUnsupportedComparator = errors.New("filter is using an unsupported comparator")
-)
+// ErrUnsupportedComparator is the error type that will be returned in the event that that an unsupported comparator
+// is used in the filter.
+type ErrUnsupportedComparator struct {
+	err error
+}
+
+// Is reports whether the provided error has the same type as ErrUnsupportedComparator. This was added as part of the new
+// error handling APIs added to Go 1.13
+func (e ErrUnsupportedComparator) Is(err error) bool {
+	return reflect.TypeOf(err) == reflect.TypeOf(e)
+}
+
+// Unwrap returns the embedded error in ErrUnsupportedComparator.
+func (e ErrUnsupportedComparator) Unwrap() error {
+	return e.err
+}
+
+func (e ErrUnsupportedComparator) Error() string {
+	return e.err.Error()
+}
 
 // MatcherError is the error type that will be returned by elemental.MatchesFilter in the event that it returns an error
 type MatcherError struct {
-	err   error
-	debug string
+	err error
 }
 
 func (me *MatcherError) Error() string {
-	var description strings.Builder
-	description.WriteString("elemental: " + me.err.Error())
-
-	// add debug copy if it is present
-	if me.debug != "" {
-		description.WriteString(" - " + me.debug)
-	}
-
-	return description.String()
+	return fmt.Sprintf("elemental: %s", me.err)
 }
 
 // Unwrap returns the the error contained in 'MatcherError'. This is a special method that aids in error handling for clients

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1261,7 +1261,7 @@ func TestUnsupportedComparators(t *testing.T) {
 
 			// this verifies that the matcher error chain contains the expected error
 
-			if !errors.Is(err, elemental.ErrUnsupportedComparator) {
+			if !errors.Is(err, elemental.ErrUnsupportedComparator{}) {
 				t.Errorf("expected the matcher error to contain an 'elemental.ErrUnsupportedComparator'\n"+
 					"actual error type: %s\n"+
 					"WARNING: this is a major breaking change as you could break client error handling logic",
@@ -1269,7 +1269,7 @@ func TestUnsupportedComparators(t *testing.T) {
 				)
 			}
 
-			expectedErrCopy := fmt.Sprintf("elemental: %s - comparator: %q", elemental.ErrUnsupportedComparator, test.comparator)
+			expectedErrCopy := fmt.Sprintf("elemental: unsupported comparator %q", test.comparator)
 			if me.Error() != expectedErrCopy {
 				t.Errorf("expected the error copy to equal: %s\n"+
 					"actual error copy: %s",
@@ -2945,34 +2945,6 @@ func TestMatchComparator(t *testing.T) {
 		})
 	}
 }
-
-//func TestMatcherError_String(t *testing.T) {
-//
-//	tests := map[string]struct {
-//		kind elemental.MatcherErrorKind
-//		want string
-//	}{
-//		"KindUnsupportedComparator": {
-//			kind: elemental.KindUnsupportedComparator,
-//			want: "KindUnsupportedComparator",
-//		},
-//		"UnknownMatcherErrorKind": {
-//			kind: elemental.MatcherErrorKind(-1),
-//			want: "UnknownMatcherErrorKind",
-//		},
-//	}
-//
-//	for scenario, test := range tests {
-//		t.Run(scenario, func(t *testing.T) {
-//			if actual := test.kind.String(); actual != test.want {
-//				t.Errorf("expected: %s\n"+
-//					"got: %s",
-//					test.want,
-//					actual)
-//			}
-//		})
-//	}
-//}
 
 type benchFixture struct {
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1284,6 +1284,11 @@ func TestErrUnsupportedComparator_Unwrap(t *testing.T) {
 	wrappedError := errors.New("something bad happened")
 	comparatorErr := elemental.ErrUnsupportedComparator{Err: wrappedError}
 
+	var err error = comparatorErr
+	if _, ok := err.(interface{ Unwrap() error }); !ok {
+		t.Fatalf("error did not have the method 'Unwrap() error'")
+	}
+
 	if actual := comparatorErr.Unwrap(); actual != wrappedError {
 		t.Errorf("the unwrapped error did not equal the expected value\n"+
 			"expected type: %s\n"+

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1269,7 +1269,7 @@ func TestUnsupportedComparators(t *testing.T) {
 				)
 			}
 
-			expectedErrCopy := fmt.Sprintf("elemental: unsupported comparator %q", test.comparator)
+			expectedErrCopy := fmt.Sprintf("elemental: unable to match: unsupported comparator %q", test.comparator)
 			if me.Error() != expectedErrCopy {
 				t.Errorf("expected the error copy to equal: %s\n"+
 					"actual error copy: %s",

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1259,16 +1259,17 @@ func TestUnsupportedComparators(t *testing.T) {
 					reflect.TypeOf(err))
 			}
 
-			if me.Kind() != elemental.KindUnsupportedComparator {
-				t.Errorf("expected *elemental.MatcherError kind to be: %s\n"+
-					"actual error kind: %s\n"+
+			// this verifies that the matcher error chain contains the expected error
+
+			if !errors.Is(err, elemental.ErrUnsupportedComparator) {
+				t.Errorf("expected the matcher error to contain an 'elemental.ErrUnsupportedComparator'\n"+
+					"actual error type: %s\n"+
 					"WARNING: this is a major breaking change as you could break client error handling logic",
-					elemental.KindUnsupportedComparator,
-					me.Kind(),
+					reflect.TypeOf(err),
 				)
 			}
 
-			expectedErrCopy := fmt.Sprintf("elemental: unsuported comparator %q - kind: %s", test.comparator, elemental.KindUnsupportedComparator)
+			expectedErrCopy := fmt.Sprintf("elemental: %s - comparator: %q", elemental.ErrUnsupportedComparator, test.comparator)
 			if me.Error() != expectedErrCopy {
 				t.Errorf("expected the error copy to equal: %s\n"+
 					"actual error copy: %s",
@@ -2945,33 +2946,33 @@ func TestMatchComparator(t *testing.T) {
 	}
 }
 
-func TestMatcherError_String(t *testing.T) {
-
-	tests := map[string]struct {
-		kind elemental.MatcherErrorKind
-		want string
-	}{
-		"KindUnsupportedComparator": {
-			kind: elemental.KindUnsupportedComparator,
-			want: "KindUnsupportedComparator",
-		},
-		"UnknownMatcherErrorKind": {
-			kind: elemental.MatcherErrorKind(-1),
-			want: "UnknownMatcherErrorKind",
-		},
-	}
-
-	for scenario, test := range tests {
-		t.Run(scenario, func(t *testing.T) {
-			if actual := test.kind.String(); actual != test.want {
-				t.Errorf("expected: %s\n"+
-					"got: %s",
-					test.want,
-					actual)
-			}
-		})
-	}
-}
+//func TestMatcherError_String(t *testing.T) {
+//
+//	tests := map[string]struct {
+//		kind elemental.MatcherErrorKind
+//		want string
+//	}{
+//		"KindUnsupportedComparator": {
+//			kind: elemental.KindUnsupportedComparator,
+//			want: "KindUnsupportedComparator",
+//		},
+//		"UnknownMatcherErrorKind": {
+//			kind: elemental.MatcherErrorKind(-1),
+//			want: "UnknownMatcherErrorKind",
+//		},
+//	}
+//
+//	for scenario, test := range tests {
+//		t.Run(scenario, func(t *testing.T) {
+//			if actual := test.kind.String(); actual != test.want {
+//				t.Errorf("expected: %s\n"+
+//					"got: %s",
+//					test.want,
+//					actual)
+//			}
+//		})
+//	}
+//}
 
 type benchFixture struct {
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1269,7 +1269,7 @@ func TestUnsupportedComparators(t *testing.T) {
 				)
 			}
 
-			expectedErrCopy := fmt.Sprintf("elemental: unable to match: unsupported comparator %q", test.comparator)
+			expectedErrCopy := fmt.Sprintf("elemental: unable to match: unsupported comparator: %q", test.comparator)
 			if me.Error() != expectedErrCopy {
 				t.Errorf("expected the error copy to equal: %s\n"+
 					"actual error copy: %s",

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1280,6 +1280,19 @@ func TestUnsupportedComparators(t *testing.T) {
 	}
 }
 
+func TestErrUnsupportedComparator_Unwrap(t *testing.T) {
+	wrappedError := errors.New("something bad happened")
+	comparatorErr := elemental.ErrUnsupportedComparator{Err: wrappedError}
+
+	if actual := comparatorErr.Unwrap(); actual != wrappedError {
+		t.Errorf("the unwrapped error did not equal the expected value\n"+
+			"expected type: %s\n"+
+			"actual type: %s",
+			reflect.TypeOf(wrappedError),
+			reflect.TypeOf(actual))
+	}
+}
+
 // this unit test suite tests the functionality of the NotEqualComparator when used in conjunction with the helper
 // MatchesFilter for filtering an AttributeSpecifiable using the supplied filter
 func TestNotEqualComparator(t *testing.T) {


### PR DESCRIPTION
### Issue: https://github.com/aporeto-inc/aporeto/issues/1699

### Summary

This PR adds a custom error type that will be returned as the error value whenever `MatchesFilter` returns an error. Client's can then use this type in their error handling strategy to properly deal with errors returned by this API.

The first client that will take advantage of this is one of Aporeto's backend services (_which is a bahamut push server_) that needs to deduce whether `MatchesFilter`  is returning an error due to the client using an unsupported filter comparator. In the event that this is the case, it will return back with some error type from it's `ShouldDispatch` callback that will indicate to bahamut that it should close the socket! That part will be added as a part of [this PR](https://github.com/aporeto-inc/bahamut/pull/82).

### Other deets

- See the test cases to get an idea on how this will be consumed by a client.