### PR TITLE
new: add support to filter parser for blacklisting filter comparators 

### DIFF
--- a/filterparser.go
+++ b/filterparser.go
@@ -129,23 +129,6 @@ var (
 		wordNOTEXISTSSP: parserTokenNOTEXISTS,
 	}
 
-	tokensToOperator = map[parserToken]string{
-		parserTokenEQUAL:       wordEQUAL,
-		parserTokenNOTEQUAL:    wordNOTEQUAL,
-		parserTokenLT:          wordLT,
-		parserTokenLTE:         wordLTE,
-		parserTokenGT:          wordGT,
-		parserTokenGTE:         wordGTE,
-		parserTokenCONTAINS:    wordCONTAINS,
-		parserTokenNOTCONTAINS: wordNOTCONTAINS,
-		parserTokenMATCHES:     wordMATCHES,
-		parserTokenIN:          wordIN,
-		parserTokenNOTIN:       wordNOTIN,
-		parserTokenNOT:         wordNOT,
-		parserTokenEXISTS:      wordEXISTS,
-		parserTokenNOTEXISTS:   wordNOTEXISTSSP,
-	}
-
 	wordToToken = map[string]parserToken{
 		wordAND:   parserTokenAND,
 		wordOR:    parserTokenOR,
@@ -361,7 +344,7 @@ func (p *FilterParser) parseOperatorAndValue() (parserToken, interface{}, error)
 	}
 
 	if _, ok := p.config.unsupportedComparators[operator]; ok {
-		return parserTokenILLEGAL, nil, fmt.Errorf("unsupported comparator:  %s", tokensToOperator[operator])
+		return parserTokenILLEGAL, nil, fmt.Errorf("unsupported comparator:  %s", tokenToOperator(operator))
 	}
 
 	if operator == parserTokenEXISTS || operator == parserTokenNOTEXISTS {
@@ -374,6 +357,17 @@ func (p *FilterParser) parseOperatorAndValue() (parserToken, interface{}, error)
 	}
 
 	return operator, value, nil
+}
+
+func tokenToOperator(t parserToken) string {
+
+	for operator, token := range operatorsToToken {
+		if t == token {
+			return operator
+		}
+	}
+
+	return ""
 }
 
 func (p *FilterParser) makeFilter(key string, operator parserToken, value interface{}) (*Filter, error) {

--- a/filterparser.go
+++ b/filterparser.go
@@ -74,8 +74,7 @@ const (
 	wordTRUE        = "TRUE"
 	wordNOT         = "NOT"
 	wordEXISTS      = "EXISTS"
-	wordNOTEXISTS   = "NOTEXISTS"
-	wordNOTEXISTSSP = "NOT EXISTS"
+	wordNOTEXISTS   = "NOT EXISTS"
 	wordEOF         = "EOF"
 )
 
@@ -126,7 +125,6 @@ var (
 		wordNOT:         parserTokenNOT,
 		wordEXISTS:      parserTokenEXISTS,
 		wordNOTEXISTS:   parserTokenNOTEXISTS,
-		wordNOTEXISTSSP: parserTokenNOTEXISTS,
 	}
 
 	wordToToken = map[string]parserToken{

--- a/filterparser_options.go
+++ b/filterparser_options.go
@@ -15,7 +15,7 @@ type FilterParserOption func(*filterParserConfig)
 // If supplied, the parser will return an error if the filter being parsed contains a comparator provided in the blacklist.
 func OptUnsupportedComparators(blacklist []FilterComparator) FilterParserOption {
 	return func(config *filterParserConfig) {
-		config.unsupportedComparators = make(map[parserToken]struct{})
+		config.unsupportedComparators = map[parserToken]struct{}{}
 		for _, c := range blacklist {
 			if token, ok := operatorsToToken[strings.ToUpper(translateComparator(c))]; ok {
 				config.unsupportedComparators[token] = struct{}{}

--- a/filterparser_options.go
+++ b/filterparser_options.go
@@ -1,0 +1,25 @@
+package elemental
+
+import "strings"
+
+type filterParserConfig struct {
+	// map to support an O(1) lookup during parsing
+	unsupportedComparators map[parserToken]struct{}
+}
+
+// FilterParserOption represents the type for the options that can be passed to `NewFilterParser` which can be used to
+// alter parsing behaviour
+type FilterParserOption func(*filterParserConfig)
+
+// OptUnsupportedComparators accepts a slice of comparators that will limit the set of comparators that the parser will accept.
+// If supplied, the parser will return an error if the filter being parsed contains a comparator provided in the blacklist.
+func OptUnsupportedComparators(blacklist []FilterComparator) FilterParserOption {
+	return func(config *filterParserConfig) {
+		config.unsupportedComparators = make(map[parserToken]struct{})
+		for _, c := range blacklist {
+			if token, ok := operatorsToToken[strings.ToUpper(translateComparator(c))]; ok {
+				config.unsupportedComparators[token] = struct{}{}
+			}
+		}
+	}
+}

--- a/filterparser_test.go
+++ b/filterparser_test.go
@@ -12,11 +12,208 @@
 package elemental
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func TestParser_UnsupportedComparator(t *testing.T) {
+
+	tests := map[string]struct {
+		filter      string
+		opts        []FilterParserOption
+		shouldError bool
+	}{
+		"blacklisting the '==' comparator should result in an error if it is used in the filter": {
+			filter: `"country" == "canada"`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				EqualComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the '==' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" == "canada"`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the '!=' comparator should result in an error if it is used in the filter": {
+			filter: `"country" != "canada"`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				NotEqualComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the '!=' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" != "canada"`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the '<' comparator should result in an error if it is used in the filter": {
+			filter: `"country" < "canada"`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				LesserComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the '<' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" < "canada"`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the '<=' comparator should result in an error if it is used in the filter": {
+			filter: `"country" <= "canada"`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				LesserOrEqualComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the '<=' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" <= "canada"`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the '>' comparator should result in an error if it is used in the filter": {
+			filter: `"country" > "canada"`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				GreaterComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the '>' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" > "canada"`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the '>=' comparator should result in an error if it is used in the filter": {
+			filter: `"country" >= "canada"`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				GreaterOrEqualComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the '>=' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" >= "canada"`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'contains' comparator should result in an error if it is used in the filter": {
+			filter: `"country" contains ["canada"]`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				ContainComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'contains' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" contains ["canada"]`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'not contains' comparator should result in an error if it is used in the filter": {
+			filter: `"country" not contains ["canada"]`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				NotContainComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'not contains' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" not contains ["canada"]`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'matches' comparator should result in an error if it is used in the filter": {
+			filter: `"country" matches ["canada"]`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				MatchComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'matches' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" matches ["canada"]`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'in' comparator should result in an error if it is used in the filter": {
+			filter: `"country" in ["canada"]`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				InComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'in' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" in ["canada"]`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'not in' comparator should result in an error if it is used in the filter": {
+			filter: `"country" not in ["canada"]`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				NotInComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'not in' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" not in ["canada"]`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'exists' comparator should result in an error if it is used in the filter": {
+			filter: `"country" exists`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				ExistsComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'exists' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" exists`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"blacklisting the 'notexists' comparator should result in an error if it is used in the filter": {
+			filter: `"country" not exists`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				NotExistsComparator,
+			})},
+			shouldError: true,
+		},
+		"NOT blacklisting the 'notexists' comparator should NOT result in an error if it is used in the filter": {
+			filter:      `"country" not exists`,
+			opts:        nil,
+			shouldError: false,
+		},
+		"should be able to deal with a complex filter": {
+			// this is a complex filter which utilizes a blacklisted comparator in a nested filter, therefore it should fail
+			// parsing
+			filter: `"namespace" == "coucou" and "number" == 32.900000 and (("name" == "toto" and "value" == 1) and ("color" contains ["red", "green", "blue", 43] and "something" in ["stuff"] or (("size" matches [".*"]) or ("size" == "medium" and "fat" == false) or ("size" in [true, false]))))`,
+			opts: []FilterParserOption{OptUnsupportedComparators([]FilterComparator{
+				MatchComparator,
+			})},
+			shouldError: true,
+		},
+	}
+
+	for scenario, tc := range tests {
+		t.Run(scenario, func(t *testing.T) {
+			parser := NewFilterParser(tc.filter, tc.opts...)
+			_, err := parser.Parse()
+			if (err != nil) != tc.shouldError {
+				t.Errorf(
+					"\n"+
+						"expected an error? %t\n"+
+						"error occurred? %t\n"+
+						"actual error: %+v",
+					tc.shouldError,
+					err != nil,
+					err)
+			}
+
+			if err != nil && !strings.Contains(err.Error(), "unsupported comparator") {
+				t.Errorf("the error returned was not due to using an unsupported comparator: %+s\n", err)
+			}
+		})
+	}
+}
 
 func TestParser_Spaces(t *testing.T) {
 

--- a/filterparser_test.go
+++ b/filterparser_test.go
@@ -215,6 +215,27 @@ func TestParser_UnsupportedComparator(t *testing.T) {
 	}
 }
 
+func Test_tokenToOperator(t *testing.T) {
+
+	tests := map[string]struct {
+		token parserToken
+		want  string
+	}{
+		"should return empty string if passed in an unknown/unsupported token": {
+			token: parserTokenILLEGAL,
+			want:  "",
+		},
+	}
+
+	for scenario, tc := range tests {
+		t.Run(scenario, func(t *testing.T) {
+			if op := tokenToOperator(tc.token); op != tc.want {
+				t.Errorf("%q did not match expected value of %q", op, tc.want)
+			}
+		})
+	}
+}
+
 func TestParser_Spaces(t *testing.T) {
 
 	Convey("Given the operator '==' is not separated by spaces but quoted", t, func() {


### PR DESCRIPTION
Resolves: https://github.com/aporeto-inc/aporeto/issues/2495

This PR adds support to the filter parser to accept a blacklist of comparators via a new functional option - `OptUnsupportedComparators`.

### Ask

- [ ]  Should we return custom error types supporting Go 1.13 error APIs? Similar to the work done w/ our [matcher errors](https://github.com/aporeto-inc/elemental/blob/master/matcher_errors.go). I am currently using `fmt.Errorf` to create the errors.

### TODO:

- [x] Add unit test coverage for new behaviour

