### PR TITLE
new: add ability to identify elemental Events

### DIFF
--- a/event.go
+++ b/event.go
@@ -36,12 +36,13 @@ const (
 
 // An Event represents a computational event.
 type Event struct {
-	RawData   []byte          `msgpack:"entity" json:"-"`
-	JSONData  json.RawMessage `msgpack:"-" json:"entity"`
-	Identity  string          `msgpack:"identity" json:"identity"`
-	Type      EventType       `msgpack:"type" json:"type"`
-	Timestamp time.Time       `msgpack:"timestamp" json:"timestamp"`
-	Encoding  EncodingType    `msgpack:"encoding" json:"encoding"`
+	PushConfigID string          `msgpack:"pushconfigid,omitempty" json:"pushconfigid,omitempty"`
+	RawData      []byte          `msgpack:"entity" json:"-"`
+	JSONData     json.RawMessage `msgpack:"-" json:"entity"`
+	Identity     string          `msgpack:"identity" json:"identity"`
+	Type         EventType       `msgpack:"type" json:"type"`
+	Timestamp    time.Time       `msgpack:"timestamp" json:"timestamp"`
+	Encoding     EncodingType    `msgpack:"encoding" json:"encoding"`
 }
 
 // NewEvent returns a new Event.

--- a/push_config.go
+++ b/push_config.go
@@ -29,6 +29,7 @@ type PushFilter = PushConfig
 // If this attribute has been supplied, the identities passed to 'IdentityFilters' must be a subset of the identities passed to
 // 'Identities'; passing in identities that are not provided in the 'Identities' field will be ignored.
 type PushConfig struct {
+	ID              string                 `msgpack:"id,omitempty" json:"id,omitempty"`
 	Identities      map[string][]EventType `msgpack:"identities" json:"identities"`
 	IdentityFilters map[string]string      `msgpack:"filters"    json:"filters"`
 	Params          url.Values             `msgpack:"parameters" json:"parameters"`
@@ -205,6 +206,8 @@ func (pc *PushConfig) Duplicate() *PushConfig {
 	for k, v := range pc.Params {
 		config.SetParameter(k, v...)
 	}
+
+	config.ID = pc.ID
 
 	return config
 }


### PR DESCRIPTION
⚠️ Dependencies (**must be merged first**):

✅ _All the PR's in this project: https://github.com/orgs/aporeto-inc/projects/759_

---

addresses https://github.com/aporeto-inc/aporeto/issues/2490 by adding an identifier field to elemental `Event` & `PushConfig` types so they can be utilized by `bahamut` to identity which push configuration an event is related to.