### PR TITLE
fix: (try to) convert the type of the `Equals` comparator's value to attribute type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - GO111MODULE=on
 
 before_install:
-- go get go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0
+- go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.3
 - go get github.com/securego/gosec/cmd/gosec
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - GO111MODULE=on
 
 before_install:
-- go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+- go get go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0
 - go get github.com/securego/gosec/cmd/gosec
 
 script:

--- a/cmd/elegen/utils.go
+++ b/cmd/elegen/utils.go
@@ -48,6 +48,7 @@ func writeFile(path string, data []byte) error {
 		return fmt.Errorf("unable to write file: %s", f.Name())
 	}
 
+	// #nosec G307
 	defer f.Close() // nolint: errcheck
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("unable to write file: %s", f.Name())

--- a/matcher.go
+++ b/matcher.go
@@ -352,6 +352,9 @@ func isString(v reflect.Value) (string, bool) {
 }
 
 func safeConvert(to reflect.Type, fromV reflect.Value) (value reflect.Value) {
+
+	// note: the call to the 'Convert' could panic in the event the usual Go conversion rules do not allow conversion
+	// of the value v to type t. hence, we need to exercise caution via recover.
 	defer func() {
 		if rv := recover(); rv != nil {
 			value = fromV

--- a/matcher.go
+++ b/matcher.go
@@ -301,6 +301,13 @@ func equalsCommon(field, value interface{}) bool {
 	default:
 		// if our field and value are not arrays/slices, then we just do a recursive equality check using Go's `==` operator via
 		// reflect.DeepEqual
+
+		// in the event that the two types are not equal, we try to convert the type of the value provided to the comparator
+		// to that of the attribute's type.
+		if fieldV.Type() != valueV.Type() {
+			value = safeConvert(fieldV.Type(), valueV).Interface()
+		}
+
 		if reflect.DeepEqual(field, value) {
 			return true
 		}
@@ -342,4 +349,14 @@ func isString(v reflect.Value) (string, bool) {
 	}
 
 	return v.String(), true
+}
+
+func safeConvert(to reflect.Type, fromV reflect.Value) (value reflect.Value) {
+	defer func() {
+		if rv := recover(); rv != nil {
+			value = fromV
+		}
+	}()
+
+	return fromV.Convert(to)
 }


### PR DESCRIPTION
@ayliao raised an issue where his filter was failing to find a match on an alarm's [`status` attribute](https://github.com/aporeto-inc/gaia/blob/2cc82a4bb719a3cbbfaeb2182b5729464436257f/alarm.go#L151). This was happening because the value provided to the comparator (a string) did not have the same type as the target attribute (`AlarmStatusValue`).

To address this in a general way, we try to convert the type of the value passed into the comparator to that of the attribute's type being filtered on.


