### PR TITLE
edit: fix gosec false positive

### DIFF
--- a/cmd/elegen/utils.go
+++ b/cmd/elegen/utils.go
@@ -48,6 +48,7 @@ func writeFile(path string, data []byte) error {
 		return fmt.Errorf("unable to write file: %s", f.Name())
 	}
 
+	// #nosec G307
 	defer f.Close() // nolint: errcheck
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("unable to write file: %s", f.Name())


### PR DESCRIPTION
What happened is upstream added a new rule to gosec to make it yell when we ignore errors from function calls https://github.com/securego/gosec/commit/7525fe4bb7b0b8b5c81d6eb011d6fdf8300ea420
this new rule subsequently caught a violation with:

```
[/home/travis/gopath/src/github.com/aporeto-inc/elemental/cmd/elegen/utils.go:51] - G307 (CWE-): Deferring unsafe method "*os.File" on type "Close" (Confidence: HIGH, Severity: MEDIUM)
  > defer f.Close()
```