### PR TITLE
new:  better support for custom mime-types

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -220,6 +220,8 @@ func EncodingFromHeaders(header http.Header) (read EncodingType, write EncodingT
 			if !supported {
 				return "", "", NewError("Unsupported Media Type", fmt.Sprintf("Cannot find any acceptable Content-Type media type in provided header: %s", v), "elemental", http.StatusUnsupportedMediaType)
 			}
+
+			read = EncodingType(ct)
 		}
 	}
 
@@ -249,6 +251,7 @@ func EncodingFromHeaders(header http.Header) (read EncodingType, write EncodingT
 				for t := range externalSupportedAcceptType {
 					if at == t {
 						agreed = true
+						write = EncodingType(at)
 						break L
 					}
 				}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -410,10 +410,15 @@ func TestEncodingFromHeader(t *testing.T) {
 
 		Convey("When I call EncodingFromHeaders", func() {
 
-			_, _, err := EncodingFromHeaders(h)
+			r, w, err := EncodingFromHeaders(h)
 
 			Convey("Then err should be nil", func() {
 				So(err, ShouldBeNil)
+			})
+
+			Convey("Then r and w should be correct", func() {
+				So(string(r), ShouldEqual, "application/aaaa")
+				So(string(w), ShouldEqual, "application/msgpack")
 			})
 		})
 	})
@@ -427,10 +432,15 @@ func TestEncodingFromHeader(t *testing.T) {
 
 		Convey("When I call EncodingFromHeaders", func() {
 
-			_, _, err := EncodingFromHeaders(h)
+			r, w, err := EncodingFromHeaders(h)
 
 			Convey("Then err should be nil", func() {
 				So(err, ShouldBeNil)
+			})
+
+			Convey("Then r and w should be correct", func() {
+				So(string(r), ShouldEqual, "application/msgpack")
+				So(string(w), ShouldEqual, "application/aaaa")
 			})
 		})
 	})

--- a/request_test.go
+++ b/request_test.go
@@ -214,6 +214,32 @@ func TestRequest_NewRequestFromHTTPRequest(t *testing.T) {
 		})
 	})
 
+	Convey("Given I have a patch http request on /lists using multipart/form-data", t, func() {
+
+		RegisterSupportedContentType("multipart/form-data")
+		defer func() { externalSupportedAcceptType = map[string]struct{}{} }()
+
+		buffer := bytes.NewBuffer([]byte(`{"name": "toto"}`))
+		req, _ := http.NewRequest(http.MethodPatch, "http://server/lists?lup1=A&lup2=true", buffer)
+		req.Header.Add("X-Namespace", "ns")
+		req.Header.Add("Authorization", "user pass")
+		req.Header.Add("Content-Type", "multipart/form-data; boundary=x")
+
+		Convey("When I create a new elemental Request from it", func() {
+
+			r, err := NewRequestFromHTTPRequest(req, Manager())
+
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then r should be correct", func() {
+				So(r.Operation, ShouldEqual, OperationPatch)
+				So(string(r.Data), ShouldEqual, "") // should not be decoded
+			})
+		})
+	})
+
 	Convey("Given I have a post http request on /lists", t, func() {
 
 		buffer := bytes.NewBuffer([]byte(`{"name": "toto"}`))
@@ -241,6 +267,33 @@ func TestRequest_NewRequestFromHTTPRequest(t *testing.T) {
 				So(r.Username, ShouldEqual, "user")
 				So(r.Password, ShouldEqual, "pass")
 				So(string(r.Data), ShouldEqual, `{"name": "toto"}`)
+			})
+		})
+	})
+
+	Convey("Given I have a post http request on /lists using multipart/form-data", t, func() {
+
+		RegisterSupportedContentType("multipart/form-data")
+		defer func() { externalSupportedAcceptType = map[string]struct{}{} }()
+
+		buffer := bytes.NewBuffer([]byte(`{"name": "toto"}`))
+		req, _ := http.NewRequest(http.MethodPost, "http://server/lists?order=name&order=toto&rlcp1=A&rlcp2=true", buffer)
+		req.Header.Add("X-Namespace", "ns")
+		req.Header.Add("Authorization", "user pass")
+		req.Header.Add("Content-Type", "multipart/form-data; boundary=x")
+
+		Convey("When I create a new elemental Request from it", func() {
+
+			r, err := NewRequestFromHTTPRequest(req, Manager())
+
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then r should be correct", func() {
+				So(r.Operation, ShouldEqual, OperationCreate)
+
+				So(string(r.Data), ShouldEqual, ``)
 			})
 		})
 	})
@@ -300,6 +353,32 @@ func TestRequest_NewRequestFromHTTPRequest(t *testing.T) {
 				So(r.Username, ShouldEqual, "user")
 				So(r.Password, ShouldEqual, "pass")
 				So(string(r.Data), ShouldEqual, `{"name": "toto"}`)
+			})
+		})
+	})
+
+	Convey("Given I have a put http request on /lists/xx using multipart/form-data", t, func() {
+
+		RegisterSupportedContentType("multipart/form-data")
+		defer func() { externalSupportedAcceptType = map[string]struct{}{} }()
+
+		buffer := bytes.NewBuffer([]byte(`{"name": "toto"}`))
+		req, _ := http.NewRequest(http.MethodPut, "http://server/lists/xx?lup1=A&lup2=true", buffer)
+		req.Header.Add("X-Namespace", "ns")
+		req.Header.Add("Authorization", "user pass")
+		req.Header.Add("Content-Type", "multipart/form-data")
+
+		Convey("When I create a new elemental Request from it", func() {
+
+			r, err := NewRequestFromHTTPRequest(req, Manager())
+
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then r should be correct", func() {
+				So(r.Operation, ShouldEqual, OperationUpdate)
+				So(string(r.Data), ShouldEqual, ``)
 			})
 		})
 	})


### PR DESCRIPTION

Do not read the body or try to decode the data when content-type or accept header is set to be one of the registered custom mime type.

This means the Data property of elemental.Request will not be populated. The handler must deal with reading the body from the internal http.Request.