### PR TITLE
new: added MakeStreamEncoder and MakeStreamDecoder

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -118,17 +118,18 @@ func TestEncodeDecode(t *testing.T) {
 	test(EncodingTypeMSGPACK)
 }
 
-func TestMakeStreamDecoder(t *testing.T) {
+func TestMakeStreamEncoderDecoder(t *testing.T) {
 
 	Convey("Given I have a bunch of json lines and a stream decoder", t, func() {
 
-		o1 := &List{Name: "1"}
-		lst1, _ := Encode(EncodingTypeJSON, o1)
-		o2 := &List{Name: "2"}
-		lst2, _ := Encode(EncodingTypeJSON, o2)
-		data := append(lst1, lst2...)
+		data := bytes.NewBuffer(nil)
+		encoder, eclose := MakeStreamEncoder(EncodingTypeJSON, data)
+		defer eclose()
 
-		decoder, close := MakeStreamDecoder(EncodingTypeJSON, bytes.NewBuffer(data))
+		encoder(&List{Name: "1"})
+		encoder(&List{Name: "2"})
+
+		decoder, close := MakeStreamDecoder(EncodingTypeJSON, data)
 		defer close()
 
 		Convey("Decoding once should work", func() {
@@ -167,13 +168,14 @@ func TestMakeStreamDecoder(t *testing.T) {
 
 	Convey("Given I have a bunch of msgpack lines and a stream decoder", t, func() {
 
-		o1 := &List{Name: "1"}
-		lst1, _ := Encode(EncodingTypeMSGPACK, o1)
-		o2 := &List{Name: "2"}
-		lst2, _ := Encode(EncodingTypeMSGPACK, o2)
-		data := append(lst1, lst2...)
+		data := bytes.NewBuffer(nil)
+		encoder, eclose := MakeStreamEncoder(EncodingTypeMSGPACK, data)
+		defer eclose()
 
-		decoder, close := MakeStreamDecoder(EncodingTypeMSGPACK, bytes.NewBuffer(data))
+		encoder(&List{Name: "1"})
+		encoder(&List{Name: "2"})
+
+		decoder, close := MakeStreamDecoder(EncodingTypeMSGPACK, data)
 		defer close()
 
 		Convey("Decoding once should work", func() {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -126,8 +126,12 @@ func TestMakeStreamEncoderDecoder(t *testing.T) {
 		encoder, eclose := MakeStreamEncoder(EncodingTypeJSON, data)
 		defer eclose()
 
-		encoder(&List{Name: "1"})
-		encoder(&List{Name: "2"})
+		if err := encoder(&List{Name: "1"}); err != nil {
+			panic(err)
+		}
+		if err := encoder(&List{Name: "2"}); err != nil {
+			panic(err)
+		}
 
 		decoder, close := MakeStreamDecoder(EncodingTypeJSON, data)
 		defer close()
@@ -172,8 +176,12 @@ func TestMakeStreamEncoderDecoder(t *testing.T) {
 		encoder, eclose := MakeStreamEncoder(EncodingTypeMSGPACK, data)
 		defer eclose()
 
-		encoder(&List{Name: "1"})
-		encoder(&List{Name: "2"})
+		if err := encoder(&List{Name: "1"}); err != nil {
+			panic(err)
+		}
+		if err := encoder(&List{Name: "2"}); err != nil {
+			panic(err)
+		}
 
 		decoder, close := MakeStreamDecoder(EncodingTypeMSGPACK, data)
 		defer close()


### PR DESCRIPTION
This patch adds the two following functions for encoding

- `func MakeStreamDecoder(encoding EncodingType, reader io.Reader) (func(dest interface{}) error, func())`
- `func MakeStreamEncoder(encoding EncodingType, writer io.Writer) (func(obj interface{}) error, func())`

Both of them return a function to perform a single encode/decode operation that can be called in a loop until `io.EOF` and a second function used to abort and put the data back in the shared memory pools.

> NOTE: there is a bug in the codec library making the JSON version unable to to retun io.EOF. See https://github.com/ugorji/go/issues/334