### PR TITLE
fix/request: Use first part of X-Forwarded-For as client IP.

### DIFF
--- a/request.go
+++ b/request.go
@@ -274,8 +274,10 @@ func NewRequestFromHTTPRequest(req *http.Request, manager ModelManager) (*Reques
 	}
 
 	var clientIP string
-	if ip := req.Header.Get("X-Forwarded-For"); ip != "" {
-		clientIP = ip
+	// Parse the Forwarded header as they can be in form
+	// X-Forwarded-For: <original_client>, [proxy1], [proxy2>
+	if ip := strings.Split(req.Header.Get("X-Forwarded-For"), ",")[0]; ip != "" {
+		clientIP = strings.TrimSpace(ip)
 	} else if ip := req.Header.Get("X-Real-IP"); ip != "" {
 		clientIP = ip
 	} else {

--- a/request.go
+++ b/request.go
@@ -276,8 +276,8 @@ func NewRequestFromHTTPRequest(req *http.Request, manager ModelManager) (*Reques
 	var clientIP string
 	// Parse the Forwarded header as they can be in form
 	// X-Forwarded-For: <original_client>, [proxy1], [proxy2>
-	if ip := strings.Split(req.Header.Get("X-Forwarded-For"), ",")[0]; ip != "" {
-		clientIP = strings.TrimSpace(ip)
+	if ip := strings.TrimSpace(strings.Split(req.Header.Get("X-Forwarded-For"), ",")[0]); ip != "" {
+		clientIP = ip
 	} else if ip := req.Header.Get("X-Real-IP"); ip != "" {
 		clientIP = ip
 	} else {

--- a/request_test.go
+++ b/request_test.go
@@ -56,7 +56,7 @@ func TestRequest_NewRequestFromHTTPRequest(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodGet, "http://server/v/10/lists?page=1&pagesize=2&recursive=true&override=true&rlgmp1=A&rlgmp2=true", nil)
 		req.Header.Set("X-Namespace", "ns")
-		req.Header.Set("X-Forwarded-for", "1.1.1.1")
+		req.Header.Set("X-Forwarded-for", "1.1.1.1, 5.5.5.5, 10.10.10.10")
 		req.Header.Set("X-Real-IP", "2.2.2.2")
 		req.Header.Set("Accept", "application/msgpack")
 		req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For, X-Forwarded-For needs to be parsed to extract the client IP.